### PR TITLE
add email

### DIFF
--- a/miqa/core/rest/__init__.py
+++ b/miqa/core/rest/__init__.py
@@ -1,4 +1,5 @@
 from .annotation import AnnotationViewSet
+from .email import EmailView
 from .experiment import ExperimentViewSet
 from .image import ImageViewSet
 from .scan import ScanViewSet
@@ -16,4 +17,5 @@ __all__ = [
     'SiteViewSet',
     'UserViewSet',
     'AnnotationViewSet',
+    'EmailView',
 ]

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -2,6 +2,7 @@ from email.mime.image import MIMEImage
 import mimetypes
 import re
 
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from rest_framework import status
 from rest_framework.response import Response
@@ -14,7 +15,7 @@ class EmailView(APIView):
         msg = EmailMultiAlternatives(
             request.data['subject'],
             request.data['body'],
-            'example@kitware.com',  # TODO: replace
+            settings.DEFAULT_FROM_EMAIL,
             request.data['to'],
             bcc=request.data['bcc'],
             cc=request.data['cc'],

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -24,8 +24,8 @@ class EmailView(APIView):
 
             # parse data uri to extract mime type and base64 data
             # assumptions: mime type is image/jpeg or image/png
-            match = re.search(
-                r'^data:(?P<mime>[\w/\-\.]+);?(\w+),(?P<data>.*)$', screenshot['dataURL']
+            match = re.fullmatch(
+                r'data:(?P<mime>[\w/\-\.]+);?(\w+),(?P<data>.*)', screenshot['dataURL']
             )
 
             if match:

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -1,0 +1,45 @@
+from email.mime.image import MIMEImage
+import mimetypes
+import re
+
+from django.core.mail import EmailMultiAlternatives
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class EmailView(APIView):
+    def post(self, request, format=None):
+
+        print(request.data['screenshots'])
+
+        msg = EmailMultiAlternatives(
+            request.data['subject'],
+            request.data['body'],
+            'example@kitware.com',  # TODO: replace
+            request.data['to'],
+            bcc=request.data['bcc'],
+            cc=request.data['cc'],
+        )
+
+        for index, screenshot in enumerate(request.data['screenshots']):
+
+            # parse data uri to extract mime type and base64 data
+            # assumptions: mime type is image/jpeg or image/png
+            match = re.search(r'^data\:(?P<mime>.+);base64,(?P<data>.+)$', screenshot['dataURL'])
+
+            if match:
+
+                mime = match.group('mime')
+                img = MIMEImage(match.group('data'), mime.split('/')[1])
+                img.add_header('Content-Id', f'<file{index}>')
+                img.add_header(
+                    'Content-Disposition',
+                    'inline',
+                    filename=screenshot['name'] + mimetypes.guess_extension(mime),
+                )
+                msg.attach(img)
+
+        msg.send()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -11,8 +11,6 @@ from rest_framework.views import APIView
 class EmailView(APIView):
     def post(self, request, format=None):
 
-        print(request.data['screenshots'])
-
         msg = EmailMultiAlternatives(
             request.data['subject'],
             request.data['body'],
@@ -26,7 +24,9 @@ class EmailView(APIView):
 
             # parse data uri to extract mime type and base64 data
             # assumptions: mime type is image/jpeg or image/png
-            match = re.search(r'^data\:(?P<mime>.+);base64,(?P<data>.+)$', screenshot['dataURL'])
+            match = re.search(
+                r'^data:(?P<mime>[\w/\-\.]+);?(\w+),(?P<data>.*)$', screenshot['dataURL']
+            )
 
             if match:
 

--- a/miqa/core/rest/user.py
+++ b/miqa/core/rest/user.py
@@ -9,10 +9,7 @@ from rest_framework.viewsets import GenericViewSet
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = [
-            'id',
-            'username',
-        ]
+        fields = ['id', 'username', 'email']
         ref_name = 'user'
 
 

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -7,6 +7,7 @@ from rest_framework import permissions, routers
 
 from miqa.core.rest import (
     AnnotationViewSet,
+    EmailView,
     ExperimentViewSet,
     ImageViewSet,
     ScanNoteViewSet,
@@ -38,6 +39,7 @@ urlpatterns = [
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('admin/', admin.site.urls),
     path('api/v1/', include(router.urls)),
+    path('api/v1/email', EmailView.as_view()),
     path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
 ]


### PR DESCRIPTION
Resolves #2

Important notes:
- Currently, emails are just being printed to console, we would need a running SMTP server or provider to send them
- Screenshot attachment logic assumes images are mime type 'image/*' where * is 'jpeg', 'png', or some other image mime type
