### PR TITLE
Fix build action branch typo

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,7 +3,7 @@ name: Build Docker Image
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
The build-docker action was running on merges to `main`, but our main
branch is `master`.