### PR TITLE
Production docker compose

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,3 +1,3 @@
 VUE_APP_API_URL=./api/v1
-VUE_APP_GIRDER_URL=./girder
-VUE_APP_STATIC_PATH=./static/miqa/
+VUE_APP_OAUTH_API_ROOT=./oauth/
+VUE_APP_STATIC_PATH=./static/

--- a/miqa/core/management/commands/makeclient.py
+++ b/miqa/core/management/commands/makeclient.py
@@ -20,8 +20,7 @@ def command(username, uri):
     application = Application(
         name='miqa-client',
         client_id='cBmD6D6F2YAmMWHNQZFPUr4OpaXVpW5w4Thod6Kj',
-        client_secret='zNkKPQjc17WfVJjIyLlqpCNdE3LYFfOTF3crpSWsMFMBvxFsqxDz0q85Rgm'
-        'BjYBX18LHB9MrygvqybJ2pmrbkAsSXquHNDVxpiEWxslp6bvQW3gWIYYuvKTyPfWvtwNU',
+        client_secret='',
         client_type='public',
         redirect_uris=uri,
         authorization_grant_type='authorization-code',

--- a/miqa/core/management/commands/makeclient.py
+++ b/miqa/core/management/commands/makeclient.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.models import User
+import djclick as click
+from oauth2_provider.models import Application
+
+
+# create django oauth toolkit appliction (client)
+@click.option('--username', type=click.STRING, help='superuser username for application creator')
+@click.option('--uri', type=click.STRING, help='redirect uri for application')
+@click.command()
+def command(username, uri):
+
+    if username:
+
+        user = User.objects.get(username=username)
+
+    else:
+
+        user = User.objects.first()
+
+    application = Application(
+        name='miqa-client',
+        client_id='cBmD6D6F2YAmMWHNQZFPUr4OpaXVpW5w4Thod6Kj',
+        client_secret='zNkKPQjc17WfVJjIyLlqpCNdE3LYFfOTF3crpSWsMFMBvxFsqxDz0q85Rgm'
+        'BjYBX18LHB9MrygvqybJ2pmrbkAsSXquHNDVxpiEWxslp6bvQW3gWIYYuvKTyPfWvtwNU',
+        client_type='public',
+        redirect_uris=uri,
+        authorization_grant_type='authorization-code',
+        user_id=user.id,
+    )
+
+    application.save()

--- a/miqa/core/rest/__init__.py
+++ b/miqa/core/rest/__init__.py
@@ -1,6 +1,7 @@
 from .annotation import AnnotationViewSet
 from .email import EmailView
 from .experiment import ExperimentViewSet
+from .home import HomePageView
 from .image import ImageViewSet
 from .scan import ScanViewSet
 from .scan_note import ScanNoteViewSet
@@ -10,6 +11,7 @@ from .user import UserViewSet
 
 __all__ = [
     'ExperimentViewSet',
+    'HomePageView',
     'ImageViewSet',
     'ScanNoteViewSet',
     'ScanViewSet',

--- a/miqa/core/rest/home.py
+++ b/miqa/core/rest/home.py
@@ -1,0 +1,20 @@
+from django.views.generic.base import TemplateView
+
+
+class HomePageView(TemplateView):
+    """
+    Serve index.html as a view, to be hosted at /.
+
+    This is used exclusively in production.
+
+    The web client is built and build artifacts are stored in `staticfiles`.
+    The whitenoise app hosts all files in `staticfiles` at `/static/`, but it would not be good UX
+    to access the web client at `http://what.ever/static/index.html`.
+
+    Instead, `staticfiles` is registered as a template directory, so this view can find it.
+    This view is then registered with the URL pattern `/`.
+    Now the web client will load when visiting `/`, despite technically being hosted at
+    `/static/index.html`.
+    """
+
+    template_name = "index.html"

--- a/miqa/core/rest/home.py
+++ b/miqa/core/rest/home.py
@@ -17,4 +17,4 @@ class HomePageView(TemplateView):
     `/static/index.html`.
     """
 
-    template_name = "index.html"
+    template_name = 'index.html'

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -7,8 +7,13 @@ from composed_configuration import (
     ConfigMixin,
     DevelopmentBaseConfiguration,
     HerokuProductionBaseConfiguration,
+    HttpsMixin,
     ProductionBaseConfiguration,
+    SmtpEmailMixin,
     TestingBaseConfiguration,
+)
+from composed_configuration._configuration import (
+    _BaseConfiguration,
 )
 
 
@@ -44,6 +49,16 @@ class TestingConfiguration(MiqaMixin, TestingBaseConfiguration):
 
 class ProductionConfiguration(MiqaMixin, ProductionBaseConfiguration):
     pass
+
+
+# TODO include HttpsMixin
+class DockerComposeProductionConfiguration(
+    MiqaMixin,
+    SmtpEmailMixin,
+    HttpsMixin,
+    _BaseConfiguration,
+):
+    """For the production deployment using docker-compose."""
 
 
 class HerokuProductionConfiguration(MiqaMixin, HerokuProductionBaseConfiguration):

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -65,7 +65,7 @@ class DockerComposeProductionConfiguration(
         # This should be STATIC_ROOT, but that is bound as a property which cannot be evaluated
         # at this point, so we make this assumption about staticfiles instead.
         configuration.TEMPLATES[0]['DIRS'] += [
-            str(Path(configuration.BASE_DIR) / 'staticfiles'),
+            configuration.BASE_DIR / 'staticfiles',
         ]
 
 

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -60,6 +60,16 @@ class DockerComposeProductionConfiguration(
 ):
     """For the production deployment using docker-compose."""
 
+    @staticmethod
+    def before_binding(configuration: ComposedConfiguration) -> None:
+        # Register static files as templates so that the index.html built by the client is
+        # available as a template.
+        # This should be STATIC_ROOT, but that is bound as a property which cannot be evaluated
+        # at this point, so we make this assumption about staticfiles instead.
+        configuration.TEMPLATES[0]['DIRS'] += [
+            str(Path(configuration.BASE_DIR) / 'staticfiles'),
+        ]
+
 
 class HerokuProductionConfiguration(MiqaMixin, HerokuProductionBaseConfiguration):
     pass

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -12,9 +12,7 @@ from composed_configuration import (
     SmtpEmailMixin,
     TestingBaseConfiguration,
 )
-from composed_configuration._configuration import (
-    _BaseConfiguration,
-)
+from composed_configuration._configuration import _BaseConfiguration
 
 
 class MiqaMixin(ConfigMixin):

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -9,6 +9,7 @@ from miqa.core.rest import (
     AnnotationViewSet,
     EmailView,
     ExperimentViewSet,
+    HomePageView,
     ImageViewSet,
     ScanNoteViewSet,
     ScanViewSet,
@@ -35,6 +36,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
+    path('', HomePageView.as_view(), name='home'),
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('admin/', admin.site.urls),

--- a/prod/.env
+++ b/prod/.env
@@ -1,0 +1,14 @@
+# Do not change
+DJANGO_CONFIGURATION=DockerComposeProductionConfiguration
+DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
+
+# Change these for your deployment
+DJANGO_ALLOWED_HOSTS=miqa.com
+DJANGO_EMAIL_URL=sumission://username:password@my.smtp.server:port
+DJANGO_DEFAULT_FROM_EMAIL=admin@miqa.com
+DJANGO_SECRET_KEY=topsecretandextremelyconfidential
+MIQA_SERVER_PORT=80
+
+# This specifies the directory to be mounted so the app can perform imports.
+# It will be mounted at the same location in the container.
+MIQA_MOUNT_DIR=/usr/var/local/miqa

--- a/prod/.env
+++ b/prod/.env
@@ -4,7 +4,7 @@ DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
 
 # Change these for your deployment
 DJANGO_ALLOWED_HOSTS=miqa.com
-DJANGO_EMAIL_URL=sumission://username:password@my.smtp.server:port
+DJANGO_EMAIL_URL=submission://username:password@my.smtp.server:port
 DJANGO_DEFAULT_FROM_EMAIL=admin@miqa.com
 DJANGO_SECRET_KEY=topsecretandextremelyconfidential
 MIQA_SERVER_PORT=80

--- a/prod/README.md
+++ b/prod/README.md
@@ -1,0 +1,84 @@
+# Production Deployment
+This directory contains everything required to deploy MIQA in production using docker-compose.
+
+# Instructions
+All of these commands should be run from the `prod` directory.
+
+### Set the variables in .env
+The `.env` file contains some default values for local testing that will need to overwritten for production deployments.
+For the build and setup process these values are mostly placeholders, but they will need to be set correctly before the site is made public.
+
+`DJANGO_EMAIL_URL` must be of the form `submission://username:password@my.smtp.server:port`. See the [documentation](https://github.com/migonzalvar/dj-email-url#supported-backends) for details with encoding special characters.
+
+You can also specify those variables explicitly in your local shell environment instead of editing the file.
+`docker-compose` will check for local shell values before defaulting to the values in `.env`.
+
+### Build the docker image
+```
+docker-compose build
+```
+
+### Apply the DB migrations
+Until you do this, the postgres DB is completely empty.
+This will not populate any data, only set up tables.
+```
+docker-compose run django ./manage.py migrate
+```
+
+### Create a superuser to administer the server
+**IMPORTANT**: Set both the Username and Email to the same valid email address.
+Admin logins will break if you do not.
+```
+docker-compose run django ./manage.py createsuperuser
+```
+
+### Run the server
+```
+docker-compose up
+```
+
+### Set up OAuth Application
+The app should now be running and accessible in your browser.
+However, you still need to set up the OAuth Application before you can log in through the web client.
+
+For this example, we will assume you are setting up `miqa.com` with `$MIQA_SERVER_PORT=80`.
+
+* In a browser, log in to the admin console at `http://miqa.com/admin` using the credentials you made earlier (email/password).
+* Click on Django OAuth Toolkit > Applications > + Add.
+* Set the following values:
+  * Client id: `cBmD6D6F2YAmMWHNQZFPUr4OpaXVpW5w4Thod6Kj`
+  * User: `1`
+  * Redirect uris: `http://miqa.com/`
+  * Client type: `Public`
+  * Authorization grant type: `Authorization code`
+  * Client secret: whatever it generated is fine
+  * Name: `MIQA GUI` (or whatever suits your fancy)
+  * Skip authorization: checked
+    * Uncheck this if you want users to explicitly authorize the app every time they log in.
+  * Algorithm: `No OIDC support` (the default).
+* Click Save.
+
+### Set up default session
+Although there are plans to support multiple sessions, currently the web client only supports one.
+This session must still be created manually.
+
+* In the admin console, click MIQA: Core > Sessions > + Add.
+* Set the following values:
+  * Name: whatever you like.
+  * Creator: your user.
+  * Import path: The path to the import CSV.
+    * You should have set `$MIQA_MOUNT_DIR` when configuring the environment variables.
+      This directory should contain the import CSV and all the files it would import.
+      This directory is mounted in the container at the same path, so the same path should be usable inside and outside the container.
+  * Export path: The path to the export CSV. See above.
+* Click Save.
+
+### Test login
+* Log out of the admin console.
+* Go to `http://miqa.com`. You should be redirected to a log in page.
+* Log in using the credentials you made earlier. You should get a prompt that an email was sent to verify your account.
+* Check your email and click the link to verify your account.
+* Log in again. You should now be logged in to the app.
+
+### Import experiments
+ * Under the Experiments tab, click Import.

--- a/prod/README.md
+++ b/prod/README.md
@@ -41,22 +41,18 @@ docker-compose up
 The app should now be running and accessible in your browser.
 However, you still need to set up the OAuth Application before you can log in through the web client.
 
-For this example, we will assume you are setting up `miqa.com` with `$MIQA_SERVER_PORT=80`.
+For this example, we will assume you are setting up `https://miqa.com/`.
 
-* In a browser, log in to the admin console at `http://miqa.com/admin` using the credentials you made earlier (email/password).
-* Click on Django OAuth Toolkit > Applications > + Add.
-* Set the following values:
-  * Client id: `cBmD6D6F2YAmMWHNQZFPUr4OpaXVpW5w4Thod6Kj`
-  * User: `1`
-  * Redirect uris: `http://miqa.com/`
-  * Client type: `Public`
-  * Authorization grant type: `Authorization code`
-  * Client secret: whatever it generated is fine
-  * Name: `MIQA GUI` (or whatever suits your fancy)
-  * Skip authorization: checked
-    * Uncheck this if you want users to explicitly authorize the app every time they log in.
-  * Algorithm: `No OIDC support` (the default).
-* Click Save.
+Set up the application by running:
+```
+docker-compose run django ./manage.py makeclient --username super.user@miqa.com --uri https://miqa.com/
+```
+
+If you have problems logging in, you can reconfigure the OAuth Application from the admin console:
+* In a browser, log in to the admin console at `https://miqa.com/admin` using the credentials you made earlier (email/password).
+* Click on Django OAuth Toolkit > Applications.
+* Click `miqa-client`.
+
 
 ### Set up default session
 Although there are plans to support multiple sessions, currently the web client only supports one.
@@ -75,7 +71,7 @@ This session must still be created manually.
 
 ### Test login
 * Log out of the admin console.
-* Go to `http://miqa.com`. You should be redirected to a log in page.
+* Go to `https://miqa.com`. You should be redirected to a log in page.
 * Log in using the credentials you made earlier. You should get a prompt that an email was sent to verify your account.
 * Check your email and click the link to verify your account.
 * Log in again. You should now be logged in to the app.

--- a/prod/django.Dockerfile
+++ b/prod/django.Dockerfile
@@ -1,0 +1,46 @@
+FROM python:3.8-slim
+# Install nodejs + npm for building client library
+# Install system libraries for Python packages:
+# * psycopg2
+RUN apt-get update && \
+    apt-get install --no-install-recommends --yes \
+    curl && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install --no-install-recommends --yes \
+    nodejs && \
+    apt-get install --no-install-recommends --yes \
+    libpq-dev gcc libc6-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Install django project
+# These arguments are required to use manage.py
+ARG DJANGO_ALLOWED_HOSTS
+ARG DJANGO_CONFIGURATION
+ARG DJANGO_DATABASE_URL
+ARG DJANGO_DEFAULT_FROM_EMAIL
+ARG DJANGO_EMAIL_URL
+ARG DJANGO_SECRET_KEY
+COPY ./setup.py /opt/django-project/setup.py
+COPY ./manage.py /opt/django-project/manage.py
+COPY ./miqa /opt/django-project/miqa
+WORKDIR /opt/django-project/
+RUN pip install . && \
+    ./manage.py collectstatic
+
+# Web client:
+# * Build
+# * Copy to staticfiles
+# * Remove node_modules, etc.
+COPY client /opt/vue-client/
+WORKDIR /opt/vue-client/
+RUN npm install \
+    && npm run build \
+    && mkdir -p /opt/django-project/staticfiles/ \
+    && mv dist/* /opt/django-project/staticfiles/ \
+    && rm -rf /opt/vue-client/
+
+# Use a directory name which will never be an import name, as isort considers this as first-party.
+WORKDIR /opt/django-project

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_DB: django
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - ${DOCKER_POSTGRES_PORT-5432}:5432
+
+  django:
+    build:
+      context: ..
+      dockerfile: ./prod/django.Dockerfile
+      args:
+        # Pass configuration variables to the build process so manage.py can be used
+        DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
+        DJANGO_CONFIGURATION: ${DJANGO_CONFIGURATION}
+        DJANGO_DATABASE_URL: ${DJANGO_DATABASE_URL}
+        DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL}
+        DJANGO_EMAIL_URL: ${DJANGO_EMAIL_URL}
+        DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+
+    # TODO install and use a wsgi server
+    command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    # Log printing via Rich is enhanced by a TTY
+    tty: true
+    env_file: ./.env
+    volumes:
+      - "${MIQA_MOUNT_DIR}:${MIQA_MOUNT_DIR}"
+    ports:
+      - ${MIQA_SERVER_PORT}:8000
+    depends_on:
+      - postgres

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ ignore =
     W503,
     # Missing docstring in *
     D10,
+extend-exclude = client
 
 [pytest]
 DJANGO_SETTINGS_MODULE = miqa.settings


### PR DESCRIPTION
`miqa-web` was already copied into the `client` directory in #59.

* Add a new directory `prod` which contains all the docker/docker-compose/documentation stuff
* The docker image builds the django app, builds the web client, then plops the built artifacts into Django's `staticfiles`. Django's whitenoise app will then serve it under `/static/`. The frontend configuration has been updated to use relative URLs since Django and the web client are now hosted on the same domain/port.
  * To get the `index.html` to be served from `/` rather than `/static/index.html`, I registered `staticfiles` as a template directory, then created a `TemplateView` which served `index.html` and registered it with the url `/`. This will technically break in development, but in development we use `npm run serve` anyway so it doesn't really matter.
* I added a new configuration that does not have any of the extra `composed-configuration` cruft (minio, Sentry, etc.)
* I added a `prod/README.md` that explicitly lists all the setup steps.

Things that are not yet finished:
- [ ] HTTPS. I developed this without the `HttpsMixin`. I ran into problems when trying to log in: after successfully authenticating and authorizing the app, Django refused to redirect me to the app with `ERROR Redirect to scheme 'http' is not permitted`. Including `HttpsMixin` doesn't work locally since nothing is there to handle the SSL termination.
I assume Jim will be using nginx or something to provide SSL termination, so it's possible that everything will just work when he deploys it.
- [ ] A WSGI server. The container work by running `./manage.py runserver 0.0.0.0:8000`. This is likely fine for now, but we should see about installing+running a real WSGI server instead.
- [ ] The logout button wasn't working for me when I tested it, but there were no console or network errors. Something to look into.