### PR TITLE
Disable SSL redirect and set SECURE_PROXY_SSL_HEADER

### DIFF
--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -56,7 +56,6 @@ class ProductionConfiguration(MiqaMixin, ProductionBaseConfiguration):
     pass
 
 
-# TODO include HttpsMixin
 class DockerComposeProductionConfiguration(
     MiqaMixin,
     SmtpEmailMixin,
@@ -91,6 +90,12 @@ class DockerComposeProductionConfiguration(
     def LOGIN_URL(self):
         """LOGIN_URL also needs to be behing MIQA_URL_PREFIX."""
         return str(Path(self.MIQA_URL_PREFIX) / 'accounts' / 'login') + '/'
+
+    # We trust the reverse proxy to redirect HTTP traffic to HTTPS
+    SECURE_SSL_REDIRECT = False
+
+    # This must be set when deployed behind a proxy
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:

--- a/prod/nginx.conf.example
+++ b/prod/nginx.conf.example
@@ -8,6 +8,7 @@ server {
   # DJANGO_MIQA_URL_PREFIX=/miqa2
   location /miqa2/ {
     # MIQA_SERVER_PORT=8000
+    proxy_set_header X-Forwarded-Proto https;
     proxy_pass http://127.0.0.1:8000/;
   }
 }


### PR DESCRIPTION
The reverse proxy was doing SSL termination and sending HTTP traffic to
django, which was then doing SSL redirection instead of handling the
traffic.

* SECURE_SSL_REDIRECT is set to False to stop this behavior.
* SECURE_PROXY_SSL_HEADER is set to ('HTTP_X_FORWARDED_PROTO', 'https')
so that when the reverse proxy sets the `X-Forwarded-Proto` header,
Django will treat the HTTP traffic as HTTPS.

The nginx example is also update to set `X-Forwarded-Proto`.