### PR TITLE
Session Lock UI

### DIFF
--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -1,11 +1,12 @@
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 
 export default {
   name: 'DataImportExport',
   components: {},
-  inject: ['djangoRest', 'mainSession'],
+  inject: ['djangoRest'],
   data: () => ({
+    ...mapState(['mainSession']),
     importing: false,
     importDialog: false,
     importErrorText: '',

--- a/client/src/components/JSONConfig.vue
+++ b/client/src/components/JSONConfig.vue
@@ -1,8 +1,11 @@
 <script>
+import { mapState } from 'vuex';
+
 export default {
   name: 'JSONConfig',
-  inject: ['djangoRest', 'mainSession'],
+  inject: ['djangoRest'],
   data: () => ({
+    ...mapState(['mainSession']),
     importpath: '',
     exportpath: '',
     changed: false,

--- a/client/src/components/SessionLock.vue
+++ b/client/src/components/SessionLock.vue
@@ -15,13 +15,7 @@ export default {
         await this.djangoRest.acquireSession(this.mainSession.id);
         this.setMainSession({ ...this.mainSession, lock_owner: this.user });
       } catch (err) {
-        if (err.response && err.response.status === 409) {
-          this.updateCurrentSession();
-          this.$snackbar({
-            text: 'The lock is held by a different user.',
-            timeout: 6000,
-          });
-        } else {
+        if (err.response && err.response.status !== 409) {
           throw err;
         }
       }
@@ -31,13 +25,7 @@ export default {
         await this.djangoRest.releaseSession(this.mainSession.id);
         this.setMainSession({ ...this.mainSession, lock_owner: null });
       } catch (err) {
-        if (err.response && err.response.status === 409) {
-          this.updateCurrentSession();
-          this.$snackbar({
-            text: 'The lock is held by a different user.',
-            timeout: 6000,
-          });
-        } else {
+        if (err.response && err.response.status !== 409) {
           throw err;
         }
       }

--- a/client/src/components/SessionLock.vue
+++ b/client/src/components/SessionLock.vue
@@ -1,0 +1,74 @@
+<script>
+import { mapState, mapMutations } from 'vuex';
+
+export default {
+  name: 'SessionLock',
+  inject: ['user', 'djangoRest'],
+  computed: {
+    ...mapState(['mainSession']),
+  },
+  methods: {
+    ...mapMutations(['setMainSession']),
+    async acquireLock() {
+      try {
+        this.djangoRest.acquireSession(this.mainSession.id);
+        this.setMainSession({ ...this.mainSession, lock_owner: this.user });
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    async releaseLock() {
+      try {
+        this.djangoRest.releaseSession(this.mainSession.id);
+        this.setMainSession({ ...this.mainSession, lock_owner: null });
+      } catch (err) {
+        console.log(err);
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <div
+    v-if="mainSession"
+    class="mr-4 d-flex align-center"
+  >
+    <span class="mr-4">Session: {{ mainSession.name }}</span>
+    <div v-if="mainSession.lock_owner">
+      <div v-if="mainSession.lock_owner.id === user.id">
+        <v-btn
+          small
+          color="green"
+          class="white--text"
+          @click="releaseLock"
+        >
+          Release
+        </v-btn>
+      </div>
+      <div v-else>
+        <v-btn
+          small
+          color="red"
+          class="disable-events white--text"
+        >
+          READ-ONLY
+        </v-btn>
+      </div>
+    </div>
+    <v-btn
+      v-else
+      small
+      color="primary"
+      @click="acquireLock"
+    >
+      Acquire
+    </v-btn>
+  </div>
+</template>
+
+<style lang="scss">
+.disable-events {
+  pointer-events: none;
+}
+</style>

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -27,6 +27,7 @@ const djangoClient = new Vue({
       apiClient.interceptors.response.use((response) => response, (error) => {
         if (error.response.status === 409) {
           // trigger snack-bar
+          this.store.dispatch('updateCurrentSession');
           this.snackbar({
             text: 'This session is owned by another user!',
             timeout: 6000,

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -50,11 +50,11 @@ const djangoClient = new Vue({
       const { results } = data;
       return results;
     },
-    async session(sessionId) {
+    async sessionDeep(sessionId) {
       const { data } = await apiClient.get(`/sessions/${sessionId}/deep`);
       return data;
     },
-    async sessionDetail(sessionId) {
+    async session(sessionId) {
       const { data } = await apiClient.get(`/sessions/${sessionId}`);
       return data;
     },

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -54,6 +54,12 @@ const djangoClient = new Vue({
       const { data } = await apiClient.get(`/sessions/${sessionId}`);
       return data;
     },
+    async acquireSession(sessionId) {
+      await apiClient.post(`/sessions/${sessionId}/lock`);
+    },
+    async releaseSession(sessionId) {
+      await apiClient.delete(`/sessions/${sessionId}/lock`);
+    },
     async settings(sessionId) {
       const { data } = await apiClient.get(`/sessions/${sessionId}/settings`);
       return data;
@@ -85,7 +91,7 @@ const djangoClient = new Vue({
       return data;
     },
     async setDecision(scanId, decision) {
-      await apiClient.post(`/annotations`, { scan: scanId, decision });
+      await apiClient.post('/annotations', { scan: scanId, decision });
     },
     async addScanNote(scanId, note) {
       await apiClient.post('/scan_notes', {

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -51,6 +51,10 @@ const djangoClient = new Vue({
       return results;
     },
     async session(sessionId) {
+      const { data } = await apiClient.get(`/sessions/${sessionId}/deep`);
+      return data;
+    },
+    async sessionDetail(sessionId) {
       const { data } = await apiClient.get(`/sessions/${sessionId}`);
       return data;
     },

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -52,14 +52,14 @@ if (process.env.NODE_ENV === 'production') {
 djangoRest.setStore(store);
 djangoRest.restoreLogin().then(async () => {
   const user = await djangoRest.me();
-  const [session] = await djangoRest.sessions();
+  await store.dispatch('getMainSession');
   new Vue({
     vuetify,
     router,
     store,
     render: (h) => h(App),
     provide: {
-      djangoRest, user, mainSession: session,
+      djangoRest, user,
     },
   })
     .$mount('#app')

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -49,7 +49,8 @@ if (process.env.NODE_ENV === 'production') {
   console.log = () => { };
 }
 
-djangoRest.setStore(store);
+djangoRest.snackbar = Vue.prototype.$snackbar;
+djangoRest.store = store;
 djangoRest.restoreLogin().then(async () => {
   const user = await djangoRest.me();
   await store.dispatch('getMainSession');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -181,6 +181,7 @@ function getNextDataset(experiments, i, j) {
 
 const initState = {
   drawer: false,
+  mainSession: null,
   experimentIds: [],
   experiments: {},
   experimentSessions: {},
@@ -327,6 +328,9 @@ const store = new Vuex.Store({
       state.sessionDatasets = {};
       state.datasets = {};
     },
+    setMainSession(state, mainSession) {
+      state.mainSession = mainSession;
+    },
     setCurrentImageId(state, imageId) {
       state.currentDatasetId = imageId;
     },
@@ -393,6 +397,11 @@ const store = new Vuex.Store({
     async logout({ dispatch }) {
       dispatch('reset');
       await djangoRest.logout();
+    },
+    async getMainSession({ commit }) {
+      const [session] = await djangoRest.sessions();
+
+      commit('setMainSession', session);
     },
     // load all nifti files into a single experiment + single scan
     async loadLocalDataset({ state, commit, dispatch }, files) {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -399,7 +399,7 @@ const store = new Vuex.Store({
       await djangoRest.logout();
     },
     async updateCurrentSession({ commit, state }) {
-      const latestSession = await djangoRest.sessionDetail(state.mainSession.id);
+      const latestSession = await djangoRest.session(state.mainSession.id);
       commit('setMainSession', latestSession);
     },
     async getMainSession({ commit }) {
@@ -487,7 +487,7 @@ const store = new Vuex.Store({
 
       if (session) {
         // load first available session
-        session = await djangoRest.session(session.id);
+        session = await djangoRest.sessionDeep(session.id);
       } else {
         // no sessions: can't load any
         return;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -398,6 +398,10 @@ const store = new Vuex.Store({
       dispatch('reset');
       await djangoRest.logout();
     },
+    async updateCurrentSession({ commit, state }) {
+      const latestSession = await djangoRest.sessionDetail(state.mainSession.id);
+      commit('setMainSession', latestSession);
+    },
     async getMainSession({ commit }) {
       const [session] = await djangoRest.sessions();
 

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -12,6 +12,7 @@ import {
 
 import Layout from '@/components/Layout.vue';
 import NavbarTitle from '@/components/NavbarTitle.vue';
+import SessionLock from '@/components/SessionLock.vue';
 import UserButton from '@/components/girder/UserButton.vue';
 import SessionsView from '@/components/SessionsView.vue';
 import WindowControl from '@/components/WindowControl.vue';
@@ -28,6 +29,7 @@ export default {
   components: {
     NavbarTitle,
     UserButton,
+    SessionLock,
     Layout,
     DataImportExport,
     SessionsView,
@@ -38,7 +40,7 @@ export default {
     KeyboardShortcutDialog,
     NavigationTabs,
   },
-  inject: ['djangoRest', 'mainSession'],
+  inject: ['djangoRest'],
   data: () => ({
     newNote: '',
     decision: null,
@@ -63,6 +65,7 @@ export default {
       'screenshots',
       'sessionCachedPercentage',
       'sessionDatasets',
+      'mainSession',
     ]),
     ...mapGetters([
       'nextDataset',
@@ -304,6 +307,7 @@ export default {
       <NavbarTitle />
       <NavigationTabs />
       <v-spacer />
+      <SessionLock />
       <v-btn
         icon
         class="mr-4"


### PR DESCRIPTION
Resolve #75 

- Move `mainSession` from inject to vuex store: Allows for changing `mainSession` (specifically `lock_owner`) more easily as well as for eventual multiple sessions
- Add section in nav bar that displays name + lock ownership for current session. Corresponding actions are:
    - Current owner: Release
    - No owner: Acquire
    - Owned by someone else: No action available