### PR TITLE
Fix screenshots

### DIFF
--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -4,6 +4,7 @@ import { mapState, mapGetters, mapMutations } from 'vuex';
 
 import { cleanDatasetName } from '@/utils/helper';
 import fill2DView from '../utils/fill2DView';
+import { getView } from '../vtk/viewManager';
 
 export default {
   name: 'VtkViewer',
@@ -19,6 +20,7 @@ export default {
     // helper to avoid size flickering
     resized: false,
     fullscreen: false,
+    screenshotContainer: document.createElement('div'),
   }),
   computed: {
     ...mapState(['proxyManager', 'loadingDataset']),
@@ -128,7 +130,10 @@ export default {
       this.slice = slice;
     },
     async takeScreenshot() {
-      const dataURL = await this.view.captureImage();
+      const view = getView(this.proxyManager, `ScreenshotView2D_${this.name}:${this.name}`, this.screenshotContainer);
+      view.getOpenglRenderWindow().setSize(512, 512);
+      fill2DView(view, 512, 512);
+      const dataURL = await view.captureImage();
       this.setCurrentScreenshot({
         name: `${this.currentSession.experiment}/${
           this.currentSession.name

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -85,7 +85,7 @@ const djangoClient = new Vue({
       return data;
     },
     async setDecision(scanId, decision) {
-      await apiClient.post(`/annotations`, { scan: scanId, decision });
+      await apiClient.post('/annotations', { scan: scanId, decision });
     },
     async addScanNote(scanId, note) {
       await apiClient.post('/scan_notes', {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -664,7 +664,8 @@ const store = new Vuex.Store({
         if (needPrep || !state.proxyManager.getViews().length) {
           prepareProxyManager(state.proxyManager);
           state.vtkViews = state.proxyManager.getViews();
-          // initializing the screenshot view resets the render settings, so do it now instead of when a screenshot is taken
+          // initializing the screenshot view resets the render settings, so do it now instead of
+          // when a screenshot is taken
           prepareScreenshotViews(state.proxyManager);
         }
         if (!state.vtkViews.length) {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -53,6 +53,12 @@ function prepareProxyManager(proxyManager) {
   }
 }
 
+function prepareScreenshotViews(proxyManager) {
+  ['ScreenshotView2D_x:x', 'ScreenshotView2D_y:y', 'ScreenshotView2D_z:z'].forEach((type) => {
+    getView(proxyManager, type, null);
+  });
+}
+
 function getArrayName(filename) {
   const idx = filename.lastIndexOf('.');
   const name = idx > -1 ? filename.substring(0, idx) : filename;
@@ -658,6 +664,8 @@ const store = new Vuex.Store({
         if (needPrep || !state.proxyManager.getViews().length) {
           prepareProxyManager(state.proxyManager);
           state.vtkViews = state.proxyManager.getViews();
+          // initializing the screenshot view resets the render settings, so do it now instead of when a screenshot is taken
+          prepareScreenshotViews(state.proxyManager);
         }
         if (!state.vtkViews.length) {
           state.vtkViews = state.proxyManager.getViews();

--- a/client/src/utils/fill2DView.js
+++ b/client/src/utils/fill2DView.js
@@ -1,4 +1,4 @@
-export default function fill2DView(view) {
+export default function fill2DView(view, w, h) {
   view.resize();
   const viewName = view.getName();
   if (viewName === 'default') return;
@@ -9,8 +9,8 @@ export default function fill2DView(view) {
     (bounds[3] - bounds[2]) / 2,
     (bounds[5] - bounds[4]) / 2,
   ];
-  const w = view.getContainer().clientWidth;
-  const h = view.getContainer().clientHeight;
+  w = w || view.getContainer().clientWidth;
+  h = h || view.getContainer().clientHeight;
   const r = w / h;
 
   let x;

--- a/client/src/vtk/proxy.js
+++ b/client/src/vtk/proxy.js
@@ -128,6 +128,9 @@ export default {
       View2D_X: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 0 }),
       View2D_Y: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 1 }),
       View2D_Z: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 2 }),
+      ScreenshotView2D_x: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 0 }),
+      ScreenshotView2D_y: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 1 }),
+      ScreenshotView2D_z: createDefaultView(vtk2DView, proxyUI.View2D, { axis: 2 }),
     },
   },
   representations: {
@@ -142,6 +145,18 @@ export default {
       vtkImageData: { name: 'SliceY' },
     },
     View2D_Z: {
+      ...proxyViewRepresentationMapping.View2D,
+      vtkImageData: { name: 'SliceZ' },
+    },
+    ScreenshotView2D_x: {
+      ...proxyViewRepresentationMapping.View2D,
+      vtkImageData: { name: 'SliceX' },
+    },
+    ScreenshotView2D_y: {
+      ...proxyViewRepresentationMapping.View2D,
+      vtkImageData: { name: 'SliceY' },
+    },
+    ScreenshotView2D_z: {
       ...proxyViewRepresentationMapping.View2D,
       vtkImageData: { name: 'SliceZ' },
     },


### PR DESCRIPTION
I found a way to piggy back on our existing view generators so I didn't have to figure out how to respecify the whole render pipeline. The `ScreenshotView2D_x/y/z` are copies of `View2D_x/y/z`, but are not mounted in the DOM. Instead, when the screenshot button is clicked, they are mounted in a disconnected div, sized appropriately, and used to capture the screenshot.