### PR TITLE
Fix production

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,3 +1,2 @@
 VUE_APP_API_URL=./api/v1
-VUE_APP_OAUTH_API_ROOT=./oauth/
 VUE_APP_STATIC_PATH=./static/

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -97,6 +97,12 @@ class DockerComposeProductionConfiguration(
     # This must be set when deployed behind a proxy
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+    # If nginx settings include an upstream definition, then the Host HTTP field may not match the
+    # Referrer HTTP field, which causes Django to reject all non-safe HTTP operations as a CSRF
+    # safeguard.
+    # To circumvent this, include the expected value of the Referrer field in this setting.
+    CSRF_TRUSTED_ORIGINS = values.ListValue(environ=True, default=[])
+
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
         # Register static files as templates so that the index.html built by the client is

--- a/prod/.env.template
+++ b/prod/.env.template
@@ -6,6 +6,9 @@ DJANGO_EMAIL_URL=submission://username:password@my.smtp.server:25
 DJANGO_DEFAULT_FROM_EMAIL=admin@miqa.com
 DJANGO_SECRET_KEY=topsecretandextremelyconfidential
 DOCKER_POSTGRES_PASSWORD=change_me
+# This should always be of the form:
+# http[s]?://${DJANGO_CSRF_TRUSTED_ORIGINS}/${DJANGO_MIQA_URL_PREFIX}/oauth/
+VUE_APP_OAUTH_API_ROOT=http://miqa.com/miqa2/oauth/
 
 # You can optionally change the below settings
 MIQA_SERVER_PORT=8000

--- a/prod/.env.template
+++ b/prod/.env.template
@@ -1,6 +1,7 @@
 # You *should* change these per deployment:
 
 DJANGO_ALLOWED_HOSTS=miqa.com
+DJANGO_CSRF_TRUSTED_ORIGINS=miqa.com
 DJANGO_EMAIL_URL=submission://username:password@my.smtp.server:25
 DJANGO_DEFAULT_FROM_EMAIL=admin@miqa.com
 DJANGO_SECRET_KEY=topsecretandextremelyconfidential

--- a/prod/.env.template
+++ b/prod/.env.template
@@ -1,6 +1,6 @@
 # You *should* change these per deployment:
 
-DJANGO_ALLOWED_HOSTS=miqa.com
+DJANGO_ALLOWED_HOSTS=miqa2
 DJANGO_CSRF_TRUSTED_ORIGINS=miqa.com
 DJANGO_EMAIL_URL=submission://username:password@my.smtp.server:25
 DJANGO_DEFAULT_FROM_EMAIL=admin@miqa.com

--- a/prod/django.Dockerfile
+++ b/prod/django.Dockerfile
@@ -37,6 +37,8 @@ RUN pip install . && \
 # * Remove node_modules, etc.
 COPY client /opt/vue-client/
 WORKDIR /opt/vue-client/
+# This is necessary so that the OAuth client knows who it's authenticating with
+ARG VUE_APP_OAUTH_API_ROOT
 RUN npm install \
     && npm run build \
     && mkdir -p /opt/django-project/staticfiles/ \

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         DJANGO_EMAIL_URL: ${DJANGO_EMAIL_URL}
         DJANGO_MIQA_URL_PREFIX: ${DJANGO_MIQA_URL_PREFIX}
         DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+        VUE_APP_OAUTH_API_ROOT: ${VUE_APP_OAUTH_API_ROOT}
 
     # TODO install and use a wsgi server
     command: ["./manage.py", "runserver", "0.0.0.0:8000"]

--- a/prod/nginx.conf.example
+++ b/prod/nginx.conf.example
@@ -1,5 +1,9 @@
 # docker run -v ~/git/miqa/prod:/etc/nginx/conf.d:ro --network=host nginx
 
+upstream miqa2 {
+  server 127.0.0.1:8000;
+}
+
 server {
   # Settings for local testing
   listen      8001;
@@ -9,6 +13,6 @@ server {
   location /miqa2/ {
     # MIQA_SERVER_PORT=8000
     proxy_set_header X-Forwarded-Proto https;
-    proxy_pass http://127.0.0.1:8000/;
+    proxy_pass http://miqa2/;
   }
 }


### PR DESCRIPTION
* `CSRF_TRUSTED_ORIGINS` is necessary for nginx configurations that use `upstream` blocks.
* `VUE_APP_OAUTH_API_ROOT` is necessary for the OAuth client to work, the previous value specified in client/.env.production was actually completely broken and failing silently.