### PR TITLE
Add web client to dev docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This is the simplest configuration for developers to start with.
 
 ### Run Application
 1. Run `docker-compose up`
-2. Access the site, starting at http://localhost:8000/admin/
+2. Access the site, starting at http://localhost:8081/
     - Note: When prompted to login with your "username" use your full email address (e.g. myname@someplace.com)
+3. The admin console can be accessed from http://localhost:8000/admin/
 4. When finished, use `Ctrl+C`
 
 ### Application Maintenance
@@ -48,6 +49,9 @@ but allows developers to run Python code on their native system.
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
    2. `celery --app miqa.celery worker --loglevel INFO --without-heartbeat`
+3. Run in a third terminal:
+   1. `cd client`
+   2. `npm run serve`
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -37,3 +37,12 @@ services:
       - postgres
       - rabbitmq
       - minio
+
+  npm:
+    image: node:latest
+    command: ["npm", "run", "serve"]
+    working_dir: /opt/client
+    volumes:
+      - ./client:/opt/client
+    ports:
+      - 8081:8081


### PR DESCRIPTION
Since the web client is now hosted in the same repo, it makes sense to
include it in the same development configuration.