### PR TITLE
Fix logout

### DIFF
--- a/miqa/core/admin.py
+++ b/miqa/core/admin.py
@@ -4,6 +4,7 @@ from django.contrib.admin.forms import AdminAuthenticationForm
 
 from .models import Annotation, Experiment, Image, Scan, ScanNote, Session, Site
 
+
 # This custom admin site only exists to ensure that admin logins are not immediately logged out,
 # as normal user logins are.
 # See the SESSION_COOKIE_AGE setting

--- a/miqa/core/admin.py
+++ b/miqa/core/admin.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
 from django.contrib import admin
+from django.contrib.admin.forms import AdminAuthenticationForm
 
 from .models import Annotation, Experiment, Image, Scan, ScanNote, Session, Site
+
+# This custom admin site only exists to ensure that admin logins are not immediately logged out,
+# as normal user logins are.
+# See the SESSION_COOKIE_AGE setting
+class CustomAdminLoginForm(AdminAuthenticationForm):
+    def confirm_login_allowed(self, user):
+        super().confirm_login_allowed(user)
+        # Admins will remain logged in for 30 minutes
+        self.request.session.set_expiry(1800)
+
+
+class CustomAdminSite(admin.AdminSite):
+    login_form = CustomAdminLoginForm
+
+
+admin.site = CustomAdminSite()
 
 
 @admin.register(Experiment)

--- a/miqa/core/management/commands/makeclient.py
+++ b/miqa/core/management/commands/makeclient.py
@@ -25,6 +25,7 @@ def command(username, uri):
         redirect_uris=uri,
         authorization_grant_type='authorization-code',
         user_id=user.id,
+        skip_authorization=True,
     )
 
     application.save()

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -23,6 +23,12 @@ class MiqaMixin(ConfigMixin):
 
     BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
+    # The session cookie should only last long enough to redirect to the web GUI.
+    # We don't want users logging out from the web GUI, getting redirected to Django, and finding
+    # that they are still logged in to the Django server, which then immediately logs them back in
+    # to the web GUI.
+    SESSION_COOKIE_AGE = 5
+
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
         # Install local apps first, to ensure any overridden resources are found first


### PR DESCRIPTION
In Girder 4, there are actually two "logins" in play: logging in to Django and the OAuth token the frontend uses to communicate with the Django API. The web GUI discards the OAuth token on logout or when the session expires, but the user still has a session cookie with Django. Django would see the unexpired session cookie and immediately issue a new OAuth token, which defeats the purpose of logging out in the first place.

This PR sets `SESSION_COOKIE_AGE` to 5 seconds, which is very short while hopefully still lasting long enough for Django to complete the OAuth flow, even under server load.

Also, create a custom Admin site that explicitly expires in 30 minutes when logging in to `/admin`. The default behavior is to use `SESSION_COOKIE_AGE` as the admin session length, which is now obviously too short.