### PR TITLE
Logout from django

### DIFF
--- a/client/src/django.js
+++ b/client/src/django.js
@@ -37,6 +37,7 @@ const djangoClient = new Vue({
       await oauthClient.redirectToLogin();
     },
     async logout() {
+      await apiClient.post('/logout/', undefined, { withCredentials: true });
       await oauthClient.logout();
     },
     async import(sessionId) {

--- a/miqa/core/management/commands/makeclient.py
+++ b/miqa/core/management/commands/makeclient.py
@@ -25,6 +25,7 @@ def command(username, uri):
         redirect_uris=uri,
         authorization_grant_type='authorization-code',
         user_id=user.id,
+        skip_authorization=True,
     )
 
     application.save()

--- a/miqa/core/rest/__init__.py
+++ b/miqa/core/rest/__init__.py
@@ -3,6 +3,7 @@ from .email import EmailView
 from .experiment import ExperimentViewSet
 from .home import HomePageView
 from .image import ImageViewSet
+from .logout import LogoutView
 from .scan import ScanViewSet
 from .scan_note import ScanNoteViewSet
 from .session import SessionViewSet
@@ -13,6 +14,7 @@ __all__ = [
     'ExperimentViewSet',
     'HomePageView',
     'ImageViewSet',
+    'LogoutView',
     'ScanNoteViewSet',
     'ScanViewSet',
     'SessionViewSet',

--- a/miqa/core/rest/logout.py
+++ b/miqa/core/rest/logout.py
@@ -1,0 +1,11 @@
+from django.contrib.auth import logout
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class LogoutView(APIView):
+    def post(self, request):
+        if request.user.is_authenticated:
+            logout(request)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -23,6 +23,12 @@ class MiqaMixin(ConfigMixin):
 
     BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
+    # Django logins should only last for 30 minutes, the same as the duration of the OAuth token.
+    SESSION_COOKIE_AGE = 1800
+
+    # This is required for the /api/v1/logout/ view to have access to the session cookie.
+    CORS_ALLOW_CREDENTIALS = True
+
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
         # Install local apps first, to ensure any overridden resources are found first

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -11,6 +11,7 @@ from miqa.core.rest import (
     ExperimentViewSet,
     HomePageView,
     ImageViewSet,
+    LogoutView,
     ScanNoteViewSet,
     ScanViewSet,
     SessionViewSet,
@@ -42,6 +43,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include(router.urls)),
     path('api/v1/email', EmailView.as_view()),
+    path('api/v1/logout/', LogoutView.as_view()),
     path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
 ]


### PR DESCRIPTION
* Add a view to explicitly log out from Django. There is an existing form at `/accounts/logout`, but it requires CSRF and the client is currently only set up to send requests to `/api/v1/...`, so it is easiest to just create a new view.
* Use that view to explicitly log out from Django when revoking the OAuth token.
* Expire the Django session after 30 minutes.