### PR TITLE
Disable session locks

### DIFF
--- a/miqa/core/rest/annotation.py
+++ b/miqa/core/rest/annotation.py
@@ -5,8 +5,6 @@ from rest_framework.viewsets import GenericViewSet
 
 from miqa.core.models import Annotation
 
-from .permissions import UserHoldsSessionLock, ensure_session_lock
-
 
 class DecisionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -28,11 +26,11 @@ class AnnotationViewSet(
     filter_backends = [filters.DjangoFilterBackend]
     filterset_fields = ['scan', 'creator']
 
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     serializer_class = DecisionSerializer
 
     def perform_create(self, serializer: DecisionSerializer):
         user = self.request.user
-        ensure_session_lock(serializer.validated_data['scan'], user)
+        # ensure_session_lock(serializer.validated_data['scan'], user)
         serializer.save(creator=user)

--- a/miqa/core/rest/experiment.py
+++ b/miqa/core/rest/experiment.py
@@ -6,8 +6,6 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from miqa.core.models import Experiment
 from miqa.core.rest.session import SessionSerializer
 
-from .permissions import UserHoldsSessionLock
-
 
 class ExperimentSerializer(serializers.ModelSerializer):
     class Meta:
@@ -24,6 +22,6 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
     filter_backends = [filters.DjangoFilterBackend]
     filterset_fields = ['session']
 
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     serializer_class = ExperimentSerializer

--- a/miqa/core/rest/image.py
+++ b/miqa/core/rest/image.py
@@ -10,8 +10,6 @@ from rest_framework.viewsets import GenericViewSet
 
 from miqa.core.models import Image
 
-from .permissions import UserHoldsSessionLock
-
 
 class ImageSerializer(serializers.ModelSerializer):
     class Meta:
@@ -27,7 +25,7 @@ class ImageViewSet(ListModelMixin, GenericViewSet):
     filter_backends = [filters.DjangoFilterBackend]
     filterset_fields = ['scan']
 
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     serializer_class = ImageSerializer
 

--- a/miqa/core/rest/scan.py
+++ b/miqa/core/rest/scan.py
@@ -5,7 +5,6 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from miqa.core.models import Annotation, Scan
 
-from .permissions import UserHoldsSessionLock
 from .scan_note import ScanNoteSerializer
 
 
@@ -31,6 +30,6 @@ class ScanViewSet(ReadOnlyModelViewSet):
     filter_backends = [filters.DjangoFilterBackend]
     filterset_fields = ['experiment', 'site']
 
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     serializer_class = ScanSerializer

--- a/miqa/core/rest/scan_note.py
+++ b/miqa/core/rest/scan_note.py
@@ -6,8 +6,6 @@ from rest_framework.viewsets import GenericViewSet
 
 from miqa.core.models import ScanNote
 
-from .permissions import UserHoldsSessionLock, ensure_session_lock
-
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -49,7 +47,7 @@ class ScanNoteViewSet(
     filter_backends = [filters.DjangoFilterBackend]
     filterset_fields = ['scan', 'initials', 'creator']
 
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     def get_serializer_class(self):
         if self.request.method == 'POST':
@@ -58,5 +56,5 @@ class ScanNoteViewSet(
 
     def perform_create(self, serializer: CreateScanNoteSerializer):
         user = self.request.user
-        ensure_session_lock(serializer.validated_data['scan'], user)
+        # ensure_session_lock(serializer.validated_data['scan'], user)
         serializer.save(creator=user, initials=user_initials(user))

--- a/miqa/core/rest/session.py
+++ b/miqa/core/rest/session.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from miqa.core.models import Annotation, Experiment, Image, Scan, ScanNote, Session
-from miqa.core.rest.permissions import LockContention, UserHoldsSessionLock
+from miqa.core.rest.permissions import LockContention
 from miqa.core.tasks import export_data, import_data
 
 
@@ -94,7 +94,7 @@ class SessionSettingsSerializer(serializers.ModelSerializer):
 
 
 class SessionViewSet(ReadOnlyModelViewSet):
-    permission_classes = [IsAuthenticated, UserHoldsSessionLock]
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         if self.action == 'retrieve':

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -146,6 +146,7 @@ def test_read_without_lock_ok(authenticated_api_client, scan_note):
     assert resp.status_code == 200
 
 
+@pytest.mark.xfail(reason='session locking is disabled')
 @pytest.mark.django_db
 def test_create_note_without_lock_fails(authenticated_api_client, scan):
     resp = authenticated_api_client.post(
@@ -159,6 +160,7 @@ def test_create_note_without_lock_fails(authenticated_api_client, scan):
     assert resp.data['detail'] == 'You must lock the session before performing this action.'
 
 
+@pytest.mark.xfail(reason='session locking is disabled')
 @pytest.mark.django_db
 def test_create_annotation_without_lock_fails(authenticated_api_client, scan):
     resp = authenticated_api_client.post(


### PR DESCRIPTION
Right now in master, users are unable to perform imports or do any other write operation without the session lock, which currently does not have a UI or any descriptive error messages on how to obtain the session lock.

Remove `UserHoldsSessionLock` from the permissions of all the views for now so that `master` is usable.