### PR TITLE
Experiment lock UI

### DIFF
--- a/client/src/components/ExperimentLockIcon.vue
+++ b/client/src/components/ExperimentLockIcon.vue
@@ -1,0 +1,83 @@
+<script>
+import { mapActions } from 'vuex';
+
+export default {
+  name: 'ExperimentLockIcon',
+  components: {},
+  props: {
+    experiment: {
+      type: Object,
+      required: true,
+    },
+  },
+  inject: ['user'],
+  methods: {
+    ...mapActions(['lockExperiment', 'unlockExperiment']),
+  },
+};
+</script>
+
+<template>
+  <v-tooltip
+    v-if="experiment.lockOwner === null"
+    right
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        icon
+        v-bind="attrs"
+        v-on="on"
+        @click="lockExperiment(experiment)"
+      >
+        <v-icon
+          small
+          color="grey"
+        >
+          mdi-lock-open
+        </v-icon>
+      </v-btn>
+    </template>
+    <span>Click to lock the experiment</span>
+  </v-tooltip>
+  <v-tooltip
+    v-else-if="experiment.lockOwner.username === user.username"
+    right
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        icon
+        v-bind="attrs"
+        v-on="on"
+        @click="unlockExperiment(experiment)"
+      >
+        <v-icon
+          small
+          color="green"
+        >
+          mdi-lock
+        </v-icon>
+      </v-btn>
+    </template>
+    <span>Click to unlock the experiment</span>
+  </v-tooltip>
+  <v-tooltip
+    v-else
+    right
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        icon
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon
+          small
+          color="orange"
+        >
+          mdi-lock
+        </v-icon>
+      </v-btn>
+    </template>
+    <span>Currently locked by {{ experiment.lockOwner.username }}</span>
+  </v-tooltip>
+</template>

--- a/client/src/components/ExperimentLockIcon.vue
+++ b/client/src/components/ExperimentLockIcon.vue
@@ -9,6 +9,10 @@ export default {
       type: Object,
       required: true,
     },
+    small: {
+      type: Boolean,
+      default: false,
+    },
   },
   inject: ['user'],
   methods: {
@@ -30,7 +34,7 @@ export default {
         @click="lockExperiment(experiment)"
       >
         <v-icon
-          small
+          :small="small"
           color="grey"
         >
           mdi-lock-open
@@ -51,7 +55,7 @@ export default {
         @click="unlockExperiment(experiment)"
       >
         <v-icon
-          small
+          :small="small"
           color="green"
         >
           mdi-lock
@@ -71,7 +75,7 @@ export default {
         v-on="on"
       >
         <v-icon
-          small
+          :small="small"
           color="orange"
         >
           mdi-lock

--- a/client/src/components/SessionsView.vue
+++ b/client/src/components/SessionsView.vue
@@ -2,10 +2,11 @@
 import _ from 'lodash';
 import { mapState, mapGetters } from 'vuex';
 import { API_URL } from '../constants';
+import ExperimentLockIcon from '@/components/ExperimentLockIcon.vue';
 
 export default {
   name: 'SessionsView',
-  components: {},
+  components: { ExperimentLockIcon },
   props: {
     minimal: {
       type: Boolean,
@@ -100,6 +101,7 @@ export default {
         >
           <v-card flat>
             {{ experiment.name }}
+            <ExperimentLockIcon :experiment="experiment" />
           </v-card>
           <v-card flat>
             <v-icon

--- a/client/src/components/SessionsView.vue
+++ b/client/src/components/SessionsView.vue
@@ -101,7 +101,10 @@ export default {
         >
           <v-card flat>
             {{ experiment.name }}
-            <ExperimentLockIcon :experiment="experiment" />
+            <ExperimentLockIcon
+              :experiment="experiment"
+              small
+            />
           </v-card>
           <v-card flat>
             <v-icon

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -74,6 +74,16 @@ const djangoClient = new Vue({
       const { results } = data;
       return results;
     },
+    async experiment(experimentId) {
+      const { data } = await apiClient.get(`/experiments/${experimentId}`);
+      return data;
+    },
+    async lockExperiment(experimentId) {
+      await apiClient.post(`/experiments/${experimentId}/lock`);
+    },
+    async unlockExperiment(experimentId) {
+      await apiClient.delete(`/experiments/${experimentId}/lock`);
+    },
     async scans(experimentId) {
       const { data } = await apiClient.get('/scans', {
         params: { experiment: experimentId },

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -696,7 +696,12 @@ const store = new Vuex.Store({
       commit('setSites', sites);
     },
     async lockExperiment({ commit }, experiment) {
-      await djangoRest.lockExperiment(experiment.id);
+      try {
+        await djangoRest.lockExperiment(experiment.id);
+      } catch {
+        // Failing to acquire the lock probably means that someone else got the lock before you.
+        // The following refresh will disable the button and show who currently owns the lock.
+      }
       const { id, name, lock_owner: lockOwner } = await djangoRest.experiment(experiment.id);
       commit('updateExperiment', {
         id,
@@ -706,7 +711,12 @@ const store = new Vuex.Store({
       });
     },
     async unlockExperiment({ commit }, experiment) {
-      await djangoRest.unlockExperiment(experiment.id);
+      try {
+        await djangoRest.unlockExperiment(experiment.id);
+      } catch {
+        // Failing to unlock the lock probably means that someone else unlocked it for you.
+        // The following refresh will show who currently owns the lock.
+      }
       const { id, name, lock_owner: lockOwner } = await djangoRest.experiment(experiment.id);
       commit('updateExperiment', {
         id,

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -530,7 +530,9 @@ const store = new Vuex.Store({
               cumulativeRange: [Number.MAX_VALUE, -Number.MAX_VALUE],
               numDatasets: images.length,
               site: scan.site,
-              notes: scan.notes,
+              // The experiment.scans.note serialization does not contain note metadata.
+              // Just set notes to [] and let reloadScan set the complete values later.
+              notes: [],
               decisions: scan.decisions,
             },
           });

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -96,7 +96,7 @@ export default {
     },
     lockOwned() {
       const { lockOwner } = this.currentExperiment;
-      return lockOwner && lockOwner.username === this.user.username;
+      return !!lockOwner && lockOwner.username === this.user.username;
     },
   },
   watch: {


### PR DESCRIPTION
Add a lock button to the UI that indicates who currently owns the experiment lock, and locks/unlocks when pressed.
The lock is present both in the session browser and in the dataset view. The notes and decision inputs are disabled when the lock is not owned by the current user.