### PR TITLE
Better import errors

### DIFF
--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -16,20 +16,14 @@ def import_data(user, session: Session):
     if session.import_path.endswith('.csv'):
         with open(session.import_path) as fd:
             csv_content = fd.read()
-            try:
-                json_content = csvContentToJsonObject(csv_content)
-                validate(json_content, schema)  # TODO this should be an internal error
-            except (ValidationError, Exception) as e:
-                raise ValidationError({'error': f'Invalid CSV file: {str(e)}'})
+            json_content = csvContentToJsonObject(csv_content)
+            validate(json_content, schema)
     elif session.import_path.endswith('.json'):
         with open(session.import_path) as json_file:
-            try:
-                json_content = json.load(json_file)
-                validate(json_content, schema)
-            except (ValidationError, Exception) as e:  # TODO this should be an internal error
-                raise ValidationError({'error': f'Invalid JSON file: {str(e)}'})
-    # else:
-    # TODO: Raise an error
+            json_content = json.load(json_file)
+            validate(json_content, schema)
+    else:
+        raise ValidationError(f'Invalid import file {session.import_path}')
 
     data_root = Path(json_content['data_root'])
 

--- a/miqa/core/tests/conftest.py
+++ b/miqa/core/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import pytest
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
@@ -30,6 +33,23 @@ def staff_api_client(api_client, user_factory) -> APIClient:
     user = user_factory(is_staff=True)
     api_client.force_authenticate(user=user)
     return api_client
+
+
+@pytest.fixture
+def samples_dir():
+    return Path(__file__).parent.parent.parent.parent / 'samples'
+
+
+@pytest.fixture
+def sample_scans(samples_dir):
+    def generator():
+        for dirpath, dirs, files in os.walk(samples_dir):
+            if 'nifti_catalog.xml' in files:
+                for dir in dirs:
+                    scan_id, scan_type = dir.split('_')
+                    yield (dirpath, scan_id, scan_type)
+
+    return [scan for scan in generator()]
 
 
 register(AnnotationFactory)

--- a/miqa/core/tests/test_import.py
+++ b/miqa/core/tests/test_import.py
@@ -106,7 +106,7 @@ def test_import_json(
 
 
 @pytest.mark.django_db
-def test_import_invalid_extension(user, session_factory, authenticated_api_client):
+def test_import_invalid_extension(user, session_factory):
     invalid_file = '/foo/bar.txt'
     session = session_factory(import_path=invalid_file)
     with pytest.raises(ValidationError, match=f'Invalid import file {invalid_file}'):
@@ -114,13 +114,7 @@ def test_import_invalid_extension(user, session_factory, authenticated_api_clien
 
 
 @pytest.mark.django_db
-def test_import_invalid_csv(
-    tmp_path: Path,
-    user,
-    session_factory,
-    sample_scans,
-    authenticated_api_client,
-):
+def test_import_invalid_csv(tmp_path: Path, user, session_factory, sample_scans):
     csv_file = str(tmp_path / 'import.csv')
     output, writer = generate_import_csv(sample_scans)
 
@@ -154,7 +148,6 @@ def test_import_invalid_json(
     session_factory,
     samples_dir: Path,
     sample_scans,
-    authenticated_api_client,
 ):
     json_file = str(tmp_path / 'import.json')
     json_content = generate_import_json(samples_dir, sample_scans)

--- a/miqa/core/tests/test_import.py
+++ b/miqa/core/tests/test_import.py
@@ -1,8 +1,176 @@
+import csv
+import io
+import json
+from pathlib import Path
+import re
+
+from jsonschema.exceptions import ValidationError
 import pytest
+
+from miqa.core.tasks import import_data
+
+
+def generate_import_csv(sample_scans):
+    output = io.StringIO()
+    fieldnames = [
+        'xnat_experiment_id',
+        'nifti_folder',
+        'scan_id',
+        'scan_type',
+        'experiment_note',
+        'decision',
+        'scan_note',
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames, dialect='unix')
+    writer.writeheader()
+    for scan_folder, scan_id, scan_type in sample_scans:
+        writer.writerow(
+            {
+                'xnat_experiment_id': 'NCANDA_DUMMY',
+                'nifti_folder': scan_folder,
+                'scan_id': scan_id,
+                'scan_type': scan_type,
+                'experiment_note': '',
+                'decision': '',
+                'scan_note': '',
+            }
+        )
+
+    return output, writer
+
+
+def generate_import_json(samples_dir: Path, sample_scans):
+    scans = []
+    for scan_folder, scan_id, scan_type in sample_scans:
+        scans.append(
+            {
+                'id': scan_id,
+                'type': scan_type,
+                'note': '',
+                'experiment_id': 'NCANDA_DUMMY',
+                'path': scan_folder,
+                'image_pattern': r'^image[\d]*\.nii\.gz$',
+                'site_id': 'test_site',
+                'decision': '',
+            }
+        )
+    experiments = [
+        {
+            'id': 'NCANDA_DUMMY',
+            'note': '',
+        }
+    ]
+    return {
+        'data_root': str(samples_dir),
+        'scans': scans,
+        'experiments': experiments,
+        'sites': [{'name': 'test_site'}],
+    }
 
 
 @pytest.mark.django_db
-def test_migrate():
-    # TODO this test can be deleted once we have real database tests.
-    # For now it's a placeholder to force the migrations to run in CI
-    assert True
+def test_import_csv(tmp_path, user, session_factory, sample_scans, authenticated_api_client):
+    csv_file = str(tmp_path / 'import.csv')
+    with open(csv_file, 'w') as fd:
+        output, _writer = generate_import_csv(sample_scans)
+        fd.write(output.getvalue())
+
+    session = session_factory(import_path=csv_file)
+
+    import_data(user, session)
+    # Test that the API import succeeds
+    resp = authenticated_api_client.post(f'/api/v1/sessions/{session.id}/import')
+    assert resp.status_code == 204
+
+
+@pytest.mark.django_db
+def test_import_json(
+    tmp_path: Path,
+    user,
+    session_factory,
+    samples_dir: Path,
+    sample_scans,
+    authenticated_api_client,
+):
+    json_file = str(tmp_path / 'import.json')
+    with open(json_file, 'w') as fd:
+        fd.write(json.dumps(generate_import_json(samples_dir, sample_scans)))
+
+    session = session_factory(import_path=json_file)
+
+    import_data(user, session)
+
+    # Test that the API import succeeds
+    resp = authenticated_api_client.post(f'/api/v1/sessions/{session.id}/import')
+    assert resp.status_code == 204
+
+
+@pytest.mark.django_db
+def test_import_invalid_extension(user, session_factory, authenticated_api_client):
+    invalid_file = '/foo/bar.txt'
+    session = session_factory(import_path=invalid_file)
+    with pytest.raises(ValidationError, match=f'Invalid import file {invalid_file}'):
+        import_data(user, session)
+
+
+@pytest.mark.django_db
+def test_import_invalid_csv(
+    tmp_path: Path,
+    user,
+    session_factory,
+    sample_scans,
+    authenticated_api_client,
+):
+    csv_file = str(tmp_path / 'import.csv')
+    output, writer = generate_import_csv(sample_scans)
+
+    # deliberately invalidate the data
+    writer.writerow(
+        {
+            'xnat_experiment_id': 'NCANDA_DUMMY',
+            # This value with no common prefix with the other scans will cause a ValueError
+            'nifti_folder': 'NOT_A_REAL_FOLDER',
+            'scan_id': '123',
+            'scan_type': 'foobar',
+            'experiment_note': '',
+            'decision': '',
+            'scan_note': '',
+        }
+    )
+
+    with open(csv_file, 'w') as fd:
+        fd.write(output.getvalue())
+
+    session = session_factory(import_path=csv_file)
+
+    with pytest.raises(ValueError, match='empty separator'):
+        import_data(user, session)
+
+
+@pytest.mark.django_db
+def test_import_invalid_json(
+    tmp_path: Path,
+    user,
+    session_factory,
+    samples_dir: Path,
+    sample_scans,
+    authenticated_api_client,
+):
+    json_file = str(tmp_path / 'import.json')
+    json_content = generate_import_json(samples_dir, sample_scans)
+
+    # deliberately invalidate the data
+    json_content['scans'][0]['site_id'] = 666
+
+    with open(json_file, 'w') as fd:
+        fd.write(json.dumps(json_content))
+
+    session = session_factory(import_path=json_file)
+
+    with pytest.raises(
+        ValidationError,
+        match=re.escape(
+            "666 is not of type 'string'\n\nFailed validating 'type' in schema['properties']['scans']['items']['properties']['site_id']:\n    {'type': 'string'}\n\nOn instance['scans'][0]['site_id']:\n    666"  # noqa: E501
+        ),
+    ):
+        import_data(user, session)


### PR DESCRIPTION
Jim's problems in #117 are utterly inscrutable because we attempt to wrap any errors in another exception, which obscures the stack trace. By removing the error handling entirely, we let django throw a 500 error on failed imports and print the stack trace.

Also add some meaningful tests for import.