### PR TITLE
Do not create an extra worker process in evaluate1

### DIFF
--- a/miqa/learning/nn_classifier.py
+++ b/miqa/learning/nn_classifier.py
@@ -284,7 +284,7 @@ def evaluate1(model, image_path):
         transform=train_transforms,
     )
     evaluation_loader = DataLoader(
-        evaluation_ds, batch_size=1, num_workers=1, pin_memory=torch.cuda.is_available()
+        evaluation_ds, batch_size=1, pin_memory=torch.cuda.is_available()
     )
 
     tensor_output = evaluate_model(model, evaluation_loader, device, None, 0, 'evaluate1')


### PR DESCRIPTION
To avoid `Task miqa.core.tasks.evaluate_data[4c98627b-d341-47ea-9a6b-a7836d515f00] raised unexpected: AssertionError('daemonic processes are not allowed to have children')`