### PR TITLE
Control panel redesign (3/3)

### DIFF
--- a/client/src/components/ControlPanel.vue
+++ b/client/src/components/ControlPanel.vue
@@ -157,7 +157,8 @@ export default {
     async handleExperimentNoteSave() {
       if (this.newExperimentNote.length > 0) {
         try {
-          await djangoRest.setExperimentNote(
+          const { updateExperiment } = store.commit;
+          const newExpData = await djangoRest.setExperimentNote(
             this.currentViewData.experimentId, this.newExperimentNote,
           );
           this.$snackbar({
@@ -165,7 +166,7 @@ export default {
             timeout: 6000,
           });
           this.newExperimentNote = '';
-          this.updateExperiment();
+          updateExperiment(newExpData);
         } catch (err) {
           this.$snackbar({
             text: `Save failed: ${err.response.data.detail || 'Server error'}`,

--- a/client/src/components/ExperimentsView.vue
+++ b/client/src/components/ExperimentsView.vue
@@ -58,7 +58,7 @@ export default {
     },
     decisionToRating(decisions) {
       if (decisions.length === 0) return {};
-      const rating = _.last(decisions).decision.toLowerCase();
+      const rating = _.last(_.sortBy(decisions, (dec) => dec.created)).decision.toLowerCase();
       switch (rating) {
         case 'good':
           return {

--- a/client/src/components/ExperimentsView.vue
+++ b/client/src/components/ExperimentsView.vue
@@ -102,7 +102,7 @@ export default {
             <v-card flat>
               {{ experiment.name }}
               <UserAvatar
-                :target-user="experiment.lockOwner"
+                :target-user="experiment.lock_owner"
                 as-editor
               />
             </v-card>

--- a/client/src/components/Navbar.vue
+++ b/client/src/components/Navbar.vue
@@ -7,11 +7,13 @@ import ScreenshotDialog from '@/components/ScreenshotDialog.vue';
 import TimeoutDialog from '@/components/TimeoutDialog.vue';
 import EmailDialog from '@/components/EmailDialog.vue';
 import KeyboardShortcutDialog from '@/components/KeyboardShortcutDialog.vue';
+import UserAvatar from '@/components/UserAvatar.vue';
 
 export default defineComponent({
   name: 'Navbar',
   inject: ['user'],
   components: {
+    UserAvatar,
     UserButton,
     ScreenshotDialog,
     EmailDialog,
@@ -119,6 +121,7 @@ export default defineComponent({
       <TimeoutDialog />
     </div>
 
+    <UserAvatar :target-user="user" />
     <UserButton
       @user="logoutUser()"
       @login="djangoRest.login()"

--- a/client/src/components/UserButton.vue
+++ b/client/src/components/UserButton.vue
@@ -19,7 +19,7 @@ export default defineComponent({
     @click="$emit('user')"
     icon
     color="black lighten-1"
-    class="mr-4"
+    class="mx-4"
   >
     Logout
   </v-btn>

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -71,10 +71,12 @@ const djangoClient = {
     return data;
   },
   async lockExperiment(experimentId: string) {
-    await apiClient.post(`/experiments/${experimentId}/lock`);
+    const { data } = await apiClient.post(`/experiments/${experimentId}/lock`);
+    return data;
   },
   async unlockExperiment(experimentId: string) {
-    await apiClient.delete(`/experiments/${experimentId}/lock`);
+    const { data } = await apiClient.delete(`/experiments/${experimentId}/lock`);
+    return data;
   },
   async scans(experimentId: string) {
     const { data } = await apiClient.get('/scans', {

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -320,8 +320,7 @@ const {
         experimentId: experiment.id,
         experimentName: experiment.name,
         experimentNote: experiment.note,
-        locked: experiment.lockOwner != null,
-        lockOwner: experiment.lockOwner,
+        lockOwner: experiment.lock_owner,
         scanId: scan.id,
         scanName: scan.name,
         scanDecisions: scan.decisions,
@@ -668,6 +667,21 @@ const {
 
       // If necessary, queue loading scans of new experiment
       checkLoadExperiment(oldExperiment, newExperiment);
+    },
+    async setLock({state, commit }, {experimentId, lock}) {
+      try {
+        if (lock) {
+          commit(
+            'updateExperiment',
+            await djangoRest.lockExperiment(experimentId)
+          );
+        } else {
+          commit(
+            'updateExperiment',
+            await djangoRest.unlockExperiment(experimentId)
+          );
+        }
+      } catch (ex) {}
     },
     startActionTimer({ state, commit }) {
       state.actionTimer = setTimeout(() => {

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -13,6 +13,7 @@ export default defineComponent({
     Navbar,
     JSONConfig,
   },
+  inject: ['user'],
   setup() {
     store.dispatch.loadProjects();
     const currentProject = computed(() => store.state.currentProject);
@@ -59,7 +60,10 @@ export default defineComponent({
         class="flex-grow-1 ma-3"
       >
         <v-card-title>Project: {{ currentProject.name }}</v-card-title>
-        <v-layout class="pa-5">
+        <v-layout
+          v-if="user.is_superuser"
+          class="pa-5"
+        >
           <v-flex>
             <JSONConfig />
           </v-flex>

--- a/miqa/core/rest/experiment.py
+++ b/miqa/core/rest/experiment.py
@@ -56,7 +56,9 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
         experiment_object = self.get_object()
         experiment_object.note = request.data['note']
         experiment_object.save()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(
+            ExperimentSerializer(experiment_object).data, status=status.HTTP_201_CREATED
+        )
 
     @swagger_auto_schema(
         request_body=no_body,

--- a/miqa/core/rest/experiment.py
+++ b/miqa/core/rest/experiment.py
@@ -80,7 +80,7 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
             if experiment.lock_owner is not None and experiment.lock_owner != request.user:
                 raise LockContention()
 
-            if experiment.lock_owner is None:
+            if experiment.lock_owner is None or experiment.lock_owner == request.user:
                 previously_locked_experiments = Experiment.objects.filter(lock_owner=request.user)
                 for previously_locked_experiment in previously_locked_experiments:
                     previously_locked_experiment.lock_owner = None

--- a/miqa/core/rest/user.py
+++ b/miqa/core/rest/user.py
@@ -1,8 +1,21 @@
 from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_out
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
+
+from miqa.core.models import Experiment
+
+
+def remove_locks(sender, user, request, **kwargs):
+    previously_locked_experiments = Experiment.objects.filter(lock_owner=request.user)
+    for previously_locked_experiment in previously_locked_experiments:
+        previously_locked_experiment.lock_owner = None
+        previously_locked_experiment.save()
+
+
+user_logged_out.connect(remove_locks)
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -99,7 +99,7 @@ def test_experiment_lock_acquire_requires_auth(api_client, experiment):
 def test_experiment_lock_acquire(api_client, experiment, user):
     api_client.force_authenticate(user=user)
     resp = api_client.post(f'/api/v1/experiments/{experiment.id}/lock')
-    assert resp.status_code == 204
+    assert resp.status_code == 200
     experiment.refresh_from_db()
     assert experiment.lock_owner == user
 
@@ -109,7 +109,7 @@ def test_experiment_lock_reacquire_ok(api_client, experiment_factory, user):
     experiment = experiment_factory(lock_owner=user)
     api_client.force_authenticate(user=user)
     resp = api_client.post(f'/api/v1/experiments/{experiment.id}/lock')
-    assert resp.status_code == 204
+    assert resp.status_code == 200
 
 
 @pytest.mark.django_db
@@ -128,7 +128,7 @@ def test_experiment_lock_release(api_client, experiment_factory, user):
     experiment = experiment_factory(lock_owner=user)
     api_client.force_authenticate(user=user)
     resp = api_client.delete(f'/api/v1/experiments/{experiment.id}/lock')
-    assert resp.status_code == 201
+    assert resp.status_code == 200
 
     experiment.refresh_from_db()
     assert experiment.lock_owner is None

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -128,7 +128,7 @@ def test_experiment_lock_release(api_client, experiment_factory, user):
     experiment = experiment_factory(lock_owner=user)
     api_client.force_authenticate(user=user)
     resp = api_client.delete(f'/api/v1/experiments/{experiment.id}/lock')
-    assert resp.status_code == 204
+    assert resp.status_code == 201
 
     experiment.refresh_from_db()
     assert experiment.lock_owner is None


### PR DESCRIPTION
The target bugs for this final PR of the control panel redesign are as follows:

- The initial for the decision made on a scan (displayed in the Experiment List as G, B, or O) should use the last decision made on that scan.
- Automatic locking and unlocking of an experiment when a reviewer opens it should work with no unexpected behavior, especially when two reviewers are interested in the same experiment.
- When an Experiment note is updated and successfully saved, the user may flip to the next scan or frame and will see the previous value again
- When a user is flipping through frames, the values for window width and window level are adjusted automatically as a guess based on the attributes of the frame. However, if the user manually sets either of these values, they should not be automatically adjusted for the rest of the scans.

Additionally, one final feature was planned for the control panel redesign effort, but it will need more consideration before implementation. The redesign concept included a feature wherein the results of an automatic evaluation from the server NN would automatically populate the reviewer's comment box so they could either agree or disagree with those results. This feature should be saved for future implementation, so it is mentioned in new issue #208.
