### PR TITLE
Run yarn build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,4 @@ jobs:
           node-version: '14'
       - run: yarn install
       - run: yarn lint --no-fix
+      - run: yarn build


### PR DESCRIPTION
This is mostly to do type checking which apparently isn't done with `lint`, but also ensures there are no other build problems.