### PR TITLE
Fix failing CI test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'django>=3.2',
+        'django>=3.2,<4.0',
         'django-allauth',
         'django-configurations[database,email]',
         'django-extensions',


### PR DESCRIPTION
Resolves #249. We specified that our version of Django is greater than 3.2, and since Django 4.0 came out today, the last CI run attempted to use Django 4.0. This broke the migrations for `oauth2_provider`. This PR simply specifies that we should use a version of Django between 3.2 and 4.0.