### PR TITLE
Clearer import errors

### DIFF
--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -44,7 +44,7 @@ export default defineComponent({
       } catch (ex) {
         importing.value = false;
         this.$snackbar({
-          text: 'Import failed. Refer to server logs for details.',
+          text: ex || 'Import failed. Refer to server logs for details.',
         });
         console.error(ex);
       }
@@ -60,7 +60,7 @@ export default defineComponent({
         });
       } catch (err) {
         this.$snackbar({
-          text: `Export failed: ${err.response.data.detail || 'Server error'}`,
+          text: err || `Export failed: ${err.response.data.detail || 'Server error'}`,
           timeout: 6000,
 
         });
@@ -103,7 +103,7 @@ export default defineComponent({
           Import
         </v-btn>
       </template>
-      <span>Import from {{ currentProject.import_path }}</span>
+      <span>Import from {{ currentProject.settings.importPath }}</span>
     </v-tooltip>
 
     <v-tooltip
@@ -131,7 +131,7 @@ export default defineComponent({
           </span>
         </v-btn>
       </template>
-      <span>Export to {{ currentProject.export_path }}</span>
+      <span>Export to {{ currentProject.settings.exportPath }}</span>
     </v-tooltip>
 
     <v-dialog

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -12,7 +12,7 @@ interface Paginated<T> {
 
 const apiClient = axios.create({ baseURL: API_URL });
 apiClient.interceptors.response.use(null, (error) => {
-  throw new Error(error.response.data.message);
+  throw new Error(error.response.data.detail);
 });
 const oauthClient = new OAuthClient(OAUTH_API_ROOT, OAUTH_CLIENT_ID);
 const djangoClient = {

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -11,6 +11,9 @@ interface Paginated<T> {
 }
 
 const apiClient = axios.create({ baseURL: API_URL });
+apiClient.interceptors.response.use(null, (error) => {
+  throw new Error(error.response.data.message);
+});
 const oauthClient = new OAuthClient(OAUTH_API_ROOT, OAUTH_CLIENT_ID);
 const djangoClient = {
   // TODO importing the actual AppStore type results in a dependency cycle

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -2,6 +2,7 @@ from drf_yasg.utils import no_body, swagger_auto_schema
 from guardian.shortcuts import get_objects_for_user, get_users_with_perms
 from rest_framework import serializers, status
 from rest_framework.decorators import action
+from rest_framework.exceptions import APIException
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -137,7 +138,7 @@ class ProjectViewSet(ReadOnlyModelViewSet):
             # tasks sent to celery must use serializable arguments
             import_data(request.user.id, project.id)
         except Exception as e:
-            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            raise APIException(str(e))
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -154,6 +155,6 @@ class ProjectViewSet(ReadOnlyModelViewSet):
             # tasks sent to celery must use serializable arguments
             export_data(project.id)
         except Exception as e:
-            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            raise APIException(str(e))
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -2,7 +2,6 @@ from drf_yasg.utils import no_body, swagger_auto_schema
 from guardian.shortcuts import get_objects_for_user, get_users_with_perms
 from rest_framework import serializers, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import APIException
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -134,11 +133,8 @@ class ProjectViewSet(ReadOnlyModelViewSet):
     def import_(self, request, **kwargs):
         project: Project = self.get_object()
 
-        try:
-            # tasks sent to celery must use serializable arguments
-            import_data(request.user.id, project.id)
-        except Exception as e:
-            raise APIException(str(e))
+        # tasks sent to celery must use serializable arguments
+        import_data(request.user.id, project.id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -151,10 +147,7 @@ class ProjectViewSet(ReadOnlyModelViewSet):
     def export(self, request, **kwargs):
         project: Project = self.get_object()
 
-        try:
-            # tasks sent to celery must use serializable arguments
-            export_data(project.id)
-        except Exception as e:
-            raise APIException(str(e))
+        # tasks sent to celery must use serializable arguments
+        export_data(project.id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -133,8 +133,11 @@ class ProjectViewSet(ReadOnlyModelViewSet):
     def import_(self, request, **kwargs):
         project: Project = self.get_object()
 
-        # tasks sent to celery must use serializable arguments
-        import_data(request.user.id, project.id)
+        try:
+            # tasks sent to celery must use serializable arguments
+            import_data(request.user.id, project.id)
+        except Exception as e:
+            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -147,7 +150,10 @@ class ProjectViewSet(ReadOnlyModelViewSet):
     def export(self, request, **kwargs):
         project: Project = self.get_object()
 
-        # tasks sent to celery must use serializable arguments
-        export_data(project.id)
+        try:
+            # tasks sent to celery must use serializable arguments
+            export_data(project.id)
+        except Exception as e:
+            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from celery import shared_task
 import pandas
+from rest_framework.exceptions import APIException
 
 from miqa.core.conversion.import_export_csvs import (
     IMPORT_CSV_COLUMNS,
@@ -51,7 +52,7 @@ def import_data(user_id, project_id):
     elif project.import_path.endswith('.json'):
         import_dict = json.load(open(project.import_path))
     else:
-        raise ValueError(f'Invalid import file {project.import_path}.')
+        raise APIException(f'Invalid import file {project.import_path}.')
 
     import_dict = validate_import_dict(import_dict, project)
     perform_import.delay(import_dict, project_id)
@@ -112,7 +113,7 @@ def export_data(project_id):
     project = Project.objects.get(id=project_id)
     parent_location = Path(project.export_path).parent
     if not parent_location.exists():
-        raise ValueError(f'No such location {parent_location} to create export file.')
+        raise APIException(f'No such location {parent_location} to create export file.')
 
     # In the event of a global export, we only want to export the projects listed in the import
     # file. Read the import file now and extract the project names.
@@ -121,7 +122,7 @@ def export_data(project_id):
     elif project.import_path.endswith('.json'):
         import_dict = json.load(open(project.import_path))
     else:
-        raise ValueError(f'Invalid import file {project.import_path}.')
+        raise APIException(f'Invalid import file {project.import_path}.')
 
     import_dict = validate_import_dict(import_dict, project)
     project_names = import_dict['projects'].keys()

--- a/miqa/core/tests/test_import.py
+++ b/miqa/core/tests/test_import.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 
 import pytest
+from rest_framework.exceptions import APIException
 
 from miqa.core.tasks import import_data
 
@@ -199,7 +200,7 @@ def test_import_global_json(
 def test_import_invalid_extension(user, project_factory):
     invalid_file = '/foo/bar.txt'
     project = project_factory(import_path=invalid_file)
-    with pytest.raises(ValueError, match=f'Invalid import file {invalid_file}'):
+    with pytest.raises(APIException, match=f'Invalid import file {invalid_file}'):
         import_data(user.id, project.id)
 
 
@@ -225,7 +226,7 @@ def test_import_invalid_csv(tmp_path: Path, user, project_factory, sample_scans)
 
     project = project_factory(import_path=csv_file)
 
-    with pytest.raises(ValueError, match='Could not locate file'):
+    with pytest.raises(APIException, match='Could not locate file'):
         import_data(user.id, project.id)
 
 
@@ -249,7 +250,7 @@ def test_import_invalid_json(
     project = project_factory(import_path=json_file)
 
     with pytest.raises(
-        ValueError,
+        APIException,
         match=re.escape('Invalid format of import file'),
     ):
         import_data(user.id, project.id)


### PR DESCRIPTION
Resolves #182.
This might resolve #251; I couldn't replicate the issue with an unpopulated import file, but I did notice that the import error messages were always vague. This PR addresses that by propagating server-side errors to the snackbar error message display in the frontend.