### PR TITLE
Fix crosshairs

### DIFF
--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -198,9 +198,11 @@ export default {
     trueAxis(axisName) {
       const orientation = this.representation.getInputDataSet().getDirection();
       const axisNumber = VIEW_ORIENTATIONS[axisName].axis;
-      const axisOrientation = orientation.slice(
-        axisNumber * 3, axisNumber * 3 + 3,
-      ).map(
+      const axisOrientation = [
+        orientation[axisNumber],
+        orientation[3 + axisNumber],
+        orientation[6 + axisNumber],
+      ].map(
         (val) => Math.abs(val),
       );
       const axisOrdering = ['x', 'y', 'z'];
@@ -270,7 +272,17 @@ export default {
             this.representation, this.view, myCanvas,
             this.iIndexSlice, this.jIndexSlice, this.kIndexSlice,
           );
-          const [displayLine1, displayLine2] = crosshairSet.getCrosshairsForAxis(this.name);
+          const originalColors = {
+            x: '#fdd835',
+            y: '#4caf50',
+            z: '#b71c1c',
+          };
+          const trueColors = Object.fromEntries(
+            Object.entries(originalColors).map(([axisName, hex]) => [this.trueAxis(axisName), hex]),
+          );
+          const [displayLine1, displayLine2] = crosshairSet.getCrosshairsForAxis(
+            this.trueAxis(this.name), trueColors,
+          );
           this.drawLine(ctx, displayLine1);
           this.drawLine(ctx, displayLine2);
         }

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -291,9 +291,6 @@ const initState = {
   screenshots: [],
   scanCachedPercentage: 0,
   showCrosshairs: true,
-  xSlice: 0,
-  ySlice: 0,
-  zSlice: 0,
   iIndexSlice: 0,
   jIndexSlice: 0,
   kIndexSlice: 0,
@@ -481,9 +478,6 @@ const {
     },
     stopLoadingExperiment(state) {
       state.loadingExperiment = false;
-    },
-    setCurrentVtkSlices(state, { axis, value }) {
-      state[`${axis}Slice`] = value;
     },
     setCurrentVtkIndexSlices(state, { indexAxis, value }) {
       state[`${indexAxis}IndexSlice`] = value;

--- a/client/src/utils/crosshairs.js
+++ b/client/src/utils/crosshairs.js
@@ -6,11 +6,6 @@ class CrosshairSet {
     this.iSlice = iSlice;
     this.jSlice = jSlice;
     this.kSlice = kSlice;
-    this.colors = {
-      i: '#fdd835',
-      j: '#4caf50',
-      k: '#b71c1c',
-    };
   }
 
   getOrientation() {
@@ -60,20 +55,19 @@ class CrosshairSet {
     };
   }
 
-  getCrosshairsForAxis(axis) {
+  getCrosshairsForAxis(axis, colors) {
     const sliceLines = this.getSliceLines();
     let horizontalLine = null;
     let verticalLine = null;
-
     if (axis === 'x') {
-      horizontalLine = Object.assign(sliceLines.k, { color: this.colors.j });
-      verticalLine = Object.assign(sliceLines.j, { color: this.colors.k });
+      horizontalLine = Object.assign(sliceLines.k, { color: colors.y });
+      verticalLine = Object.assign(sliceLines.j, { color: colors.z });
     } else if (axis === 'y') {
-      horizontalLine = Object.assign(sliceLines.k, { color: this.colors.i });
-      verticalLine = Object.assign(sliceLines.i, { color: this.colors.k });
+      horizontalLine = Object.assign(sliceLines.k, { color: colors.x });
+      verticalLine = Object.assign(sliceLines.i, { color: colors.z });
     } else if (axis === 'z') {
-      horizontalLine = Object.assign(sliceLines.j, { color: this.colors.i });
-      verticalLine = Object.assign(sliceLines.i, { color: this.colors.j });
+      horizontalLine = Object.assign(sliceLines.j, { color: colors.x });
+      verticalLine = Object.assign(sliceLines.i, { color: colors.y });
     }
 
     return [horizontalLine, verticalLine];

--- a/client/src/utils/crosshairs.js
+++ b/client/src/utils/crosshairs.js
@@ -1,0 +1,83 @@
+class CrosshairSet {
+  constructor(imageRepresentation, imageView, imageCanvas, iSlice, jSlice, kSlice) {
+    this.imageRepresentation = imageRepresentation;
+    this.imageView = imageView;
+    this.imageCanvas = imageCanvas;
+    this.iSlice = iSlice;
+    this.jSlice = jSlice;
+    this.kSlice = kSlice;
+    this.colors = {
+      i: '#fdd835',
+      j: '#4caf50',
+      k: '#b71c1c',
+    };
+  }
+
+  getOrientation() {
+    return this.imageRepresentation.getInputDataSet().getDirection();
+  }
+
+  getSliceLines() {
+    const imageData = this.imageRepresentation.getInputDataSet();
+    const [iMax, jMax, kMax] = imageData.getDimensions();
+    const renderer = this.imageView.getRenderer();
+    const renderWindow = this.imageView.getOpenglRenderWindow();
+
+    const iRepresentation = [
+      [0, this.jSlice, this.kSlice],
+      [iMax - 1, this.jSlice, this.kSlice],
+    ];
+    const jRepresentation = [
+      [this.iSlice, 0, this.kSlice],
+      [this.iSlice, jMax - 1, this.kSlice],
+    ];
+    const kRepresentation = [
+      [this.iSlice, this.jSlice, 0],
+      [this.iSlice, this.jSlice, kMax - 1],
+    ];
+    const [iPoints, jPoints, kPoints] = [iRepresentation, jRepresentation, kRepresentation].map(
+      (representation) => [
+        imageData.indexToWorld(representation[0]),
+        imageData.indexToWorld(representation[1]),
+      ].map(
+        (point) => renderWindow.worldToDisplay(point[0], point[1], point[2], renderer)
+          .map((c) => c / devicePixelRatio).slice(0, 2),
+      ).map((point) => [point[0], this.imageCanvas.height - point[1]]),
+    );
+    return {
+      i: {
+        start: iPoints[0],
+        end: iPoints[1],
+      },
+      j: {
+        start: jPoints[0],
+        end: jPoints[1],
+      },
+      k: {
+        start: kPoints[0],
+        end: kPoints[1],
+      },
+    };
+  }
+
+  getCrosshairsForAxis(axis) {
+    const sliceLines = this.getSliceLines();
+    let horizontalLine = null;
+    let verticalLine = null;
+
+    if (axis === 'x') {
+      horizontalLine = Object.assign(sliceLines.k, { color: this.colors.j });
+      verticalLine = Object.assign(sliceLines.j, { color: this.colors.k });
+    } else if (axis === 'y') {
+      horizontalLine = Object.assign(sliceLines.k, { color: this.colors.i });
+      verticalLine = Object.assign(sliceLines.i, { color: this.colors.k });
+    } else if (axis === 'z') {
+      horizontalLine = Object.assign(sliceLines.j, { color: this.colors.i });
+      verticalLine = Object.assign(sliceLines.i, { color: this.colors.j });
+    }
+
+    return [horizontalLine, verticalLine];
+  }
+}
+
+export default CrosshairSet;


### PR DESCRIPTION
After the changes made to `VtkViewer` to fix the camera placement for flipped/rotated/axis-switched images, the assumptions made for drawing crosshairs were no longer correct. This PR changes the crosshairs logic to account for this.