### PR TITLE
Improve vtk viewer toolbar positioning

### DIFF
--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -364,8 +364,9 @@ export default {
       class="toolbar"
       dark
       flat
-      color="black"
-      max-height="42"
+      color="#ffffff00"
+      height="46"
+      max-height="46"
     >
       <div
         :class="name"


### PR DESCRIPTION
It now no longer overflows the container. Before:

<img width="566" alt="Screen Shot 2022-01-04 at 1 46 21 PM" src="https://user-images.githubusercontent.com/555959/148108462-2019d845-b48e-41af-b822-21c9b48d625a.png">


After:

<img width="568" alt="Screen Shot 2022-01-04 at 1 45 16 PM" src="https://user-images.githubusercontent.com/555959/148108402-6772d11b-4065-4cd6-a90d-6b2b96a1cc07.png">

