### PR TITLE
Enable navigating directly to Frame

### DIFF
--- a/client/src/components/ControlPanel.vue
+++ b/client/src/components/ControlPanel.vue
@@ -32,7 +32,6 @@ export default {
     ...mapGetters([
       'currentViewData',
       'nextFrame',
-      'getFrame',
       'previousFrame',
       'currentFrame',
       'myCurrentProjectRoles',
@@ -163,7 +162,7 @@ export default {
     navigateToFrame(frameId) {
       if (frameId && frameId !== this.$route.params.frameId) {
         this.$router
-          .push(frameId || '')
+          .push(`${this.currentViewData.projectId}/${frameId}` || '')
           .catch(this.handleNavigationError);
       }
     },

--- a/client/src/components/ControlPanel.vue
+++ b/client/src/components/ControlPanel.vue
@@ -162,7 +162,7 @@ export default {
     navigateToFrame(frameId) {
       if (frameId && frameId !== this.$route.params.frameId) {
         this.$router
-          .push(`${this.currentViewData.projectId}/${frameId}` || '')
+          .push(`/${this.currentViewData.projectId}/${frameId}` || '')
           .catch(this.handleNavigationError);
       }
     },

--- a/client/src/components/ExperimentsView.vue
+++ b/client/src/components/ExperimentsView.vue
@@ -27,6 +27,7 @@ export default {
       'scans',
       'scanFrames',
       'frames',
+      'currentProject',
     ]),
     ...mapGetters(['currentScan', 'currentExperiment']),
     orderedExperiments() {
@@ -58,8 +59,8 @@ export default {
         };
       });
     },
-    getIdOfFirstFrameInScan(scanId) {
-      return `${this.scanFrames[scanId][0]}`;
+    getURLForFirstFrameInScan(scanId) {
+      return `${this.currentProject.id}/${this.scanFrames[scanId][0]}`;
     },
     decisionToRating(decisions) {
       if (decisions.length === 0) return {};
@@ -120,7 +121,7 @@ export default {
               class="body-1"
             >
               <v-btn
-                :to="getIdOfFirstFrameInScan(scan.id)"
+                :to="getURLForFirstFrameInScan(scan.id)"
                 class="ml-0 px-1 scan-name"
                 href
                 text

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -15,7 +15,7 @@ export default new Router({
     },
     // Order matters
     {
-      path: '/:frameId?',
+      path: '/:projectId?/:frameId?',
       name: 'frame',
       component: Frame,
     },

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -347,6 +347,7 @@ const {
         downTo = null;
       }
       return {
+        projectId: project.id,
         projectName: project.name,
         experimentId: experiment.id,
         experimentName: experiment.name,
@@ -377,14 +378,6 @@ const {
     },
     nextFrame(state, getters) {
       return getters.currentFrame ? getters.currentFrame.nextFrame : null;
-    },
-    getFrame(state) {
-      return (frameId) => {
-        if (!frameId || !state.frames[frameId]) {
-          return undefined;
-        }
-        return state.frames[frameId];
-      };
     },
     currentScan(state, getters) {
       if (getters.currentFrame) {
@@ -685,6 +678,16 @@ const {
           decisions: scan.decisions,
         },
       });
+    },
+    async getFrame({ state, dispatch }, { frameId, projectId }) {
+      if (!frameId) {
+        return undefined;
+      } else if (!state.frames[frameId]){
+        await dispatch('loadProjects')
+        const targetProject = state.projects.filter((proj) => proj.id === projectId)[0]
+        await dispatch('loadProject', targetProject)
+      }
+      return state.frames[frameId];
     },
     async setCurrentFrame({ commit, dispatch }, frameId) {
       commit('setCurrentFrameId', frameId);

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -682,7 +682,8 @@ const {
     async getFrame({ state, dispatch }, { frameId, projectId }) {
       if (!frameId) {
         return undefined;
-      } if (!state.frames[frameId]) {
+      }
+      if (!state.frames[frameId]) {
         await dispatch('loadProjects');
         const targetProject = state.projects.filter((proj) => proj.id === projectId)[0];
         await dispatch('loadProject', targetProject);

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -682,10 +682,10 @@ const {
     async getFrame({ state, dispatch }, { frameId, projectId }) {
       if (!frameId) {
         return undefined;
-      } else if (!state.frames[frameId]){
-        await dispatch('loadProjects')
-        const targetProject = state.projects.filter((proj) => proj.id === projectId)[0]
-        await dispatch('loadProject', targetProject)
+      } if (!state.frames[frameId]) {
+        await dispatch('loadProjects');
+        const targetProject = state.projects.filter((proj) => proj.id === projectId)[0];
+        await dispatch('loadProject', targetProject);
       }
       return state.frames[frameId];
     },

--- a/client/src/views/Frame.vue
+++ b/client/src/views/Frame.vue
@@ -28,7 +28,6 @@ export default {
       'errorLoadingFrame',
     ]),
     ...mapGetters([
-      'getFrame',
       'currentFrame',
     ]),
     currentScanFrames() {
@@ -50,8 +49,8 @@ export default {
       this.debouncedFrameSliderChange,
       30,
     );
-    const { frameId } = this.$route.params;
-    const frame = this.getFrame(frameId);
+    const { projectId, frameId } = this.$route.params;
+    const frame = await this.getFrame({ frameId, projectId });
     if (frame) {
       await this.swapToFrame(frame);
     } else {
@@ -59,7 +58,7 @@ export default {
     }
   },
   async beforeRouteUpdate(to, from, next) {
-    const toFrame = this.getFrame(to.params.frameId);
+    const toFrame = await this.getFrame({ frameId: to.params.frameId, projectId: undefined });
     next(true);
     if (toFrame) {
       this.swapToFrame(toFrame);
@@ -74,6 +73,7 @@ export default {
       'reloadScan',
       'logout',
       'swapToFrame',
+      'getFrame',
     ]),
     cleanFrameName,
     async logoutUser() {


### PR DESCRIPTION
Resolves #233. I went with @dchiquito's suggestion to include the project id in the url.

I left the following line in just in case there is some failure to load the project:
```
this.$router.replace('/').catch(this.handleNavigationError);
```
But, in most cases, this line is not reached.