### PR TITLE
Ghosting quality 8 works best on the 5 folds of the big set

### DIFF
--- a/miqa/learning/models/miqaT1-val0.pth
+++ b/miqa/learning/models/miqaT1-val0.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0168f5385a9f260cfa3982ddeab8cbcec3f144be88cede034d206178c829f1da
-size 1218585
+oid sha256:e90c4053cbd2ea12f6590a09f3f7a859a6a7eb1ce55f4906100b5202e3342e4c
+size 1218581

--- a/miqa/learning/models/miqaT1-val1.pth
+++ b/miqa/learning/models/miqaT1-val1.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1e9bba23cffa900d9547f1374f108a7ac5717daa91d94ce2a7f8bff8a122cbc
-size 1218686
+oid sha256:231e87802d910d9d83877c1772a440d15065602cbe7f63185bd5fb894796b66f
+size 1218685

--- a/miqa/learning/models/miqaT1-val2.pth
+++ b/miqa/learning/models/miqaT1-val2.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7bfaa798330384f172849396324e53ded8f0ad10eb5e6fb27bec6e1ca5b4844e
-size 1218673
+oid sha256:0d0612367224aecd9923e9f28a08cbf963515874cf50344f9e73708ca59c398d
+size 1218679

--- a/miqa/learning/models/miqaT1-val3.pth
+++ b/miqa/learning/models/miqaT1-val3.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48eeebf3d4b8edb0d176d783e55ec194d1c21bd942c5032a9345e8e28217ff2a
-size 1218683
+oid sha256:2383ca324c646ed7075e8e726a6994dc1b4e76958441fd3d165bd8fc2f300757
+size 1218675

--- a/miqa/learning/models/miqaT1-val4.pth
+++ b/miqa/learning/models/miqaT1-val4.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:488518f2e35c3f9289a3e7f26c6114802e8fa1d3c7240a189dfac10ce3e15dbd
-size 1218687
+oid sha256:0a26bac711a6d62050adf840f3efbb576f8da22323a50060f2c7d4143b7866f9
+size 1218686

--- a/miqa/learning/nn_training.py
+++ b/miqa/learning/nn_training.py
@@ -206,7 +206,7 @@ class CustomGhosting(torchio.transforms.RandomGhosting):
             applied_params = transformed_subject.applied_transforms[-1][1]
             intensity = applied_params['intensity']['img']
             num_ghosts = applied_params['num_ghosts']['img']
-            quality_reduction = 7 * intensity * math.log10(num_ghosts)
+            quality_reduction = 8 * intensity * math.log10(num_ghosts)
 
             # update the ground truth information
             new_quality = original_quality - quality_reduction


### PR DESCRIPTION
5-fold cross-validation test on the big dataset says that ghosting quality factor 8 works better than 7. On just the first fold, 7 worked slightly better.