### PR TITLE
Add support for nrrd and mgz file types

### DIFF
--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -228,7 +228,7 @@ function checkLoadExperiment(oldValue, newValue) {
   const newExperimentScans = store.state.experimentScans[newValue.id];
   newExperimentScans.forEach((scanId) => {
     const scanFrames = store.state.scanFrames[scanId].map(
-      (frameId) => store.state.frames[frameId]
+      (frameId) => store.state.frames[frameId],
     );
     scanFrames.forEach((frame) => {
       readDataQueue.push({
@@ -774,7 +774,9 @@ const {
         if (frameCache.has(frame.id)) {
           frameData = frameCache.get(frame.id).frameData;
         } else {
-          const result = await loadFileAndGetData(frame.id, frame.extension, { onDownloadProgress });
+          const result = await loadFileAndGetData(
+            frame.id, frame.extension, { onDownloadProgress },
+          );
           frameData = result.frameData;
         }
         sourceProxy.setInputData(frameData);

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -105,13 +105,13 @@ function getData(id, file, webWorker = null) {
   });
 }
 
-function loadFile(frameId, { onDownloadProgress = null } = {}) {
+function loadFile(frameId, frameExtension, { onDownloadProgress = null } = {}) {
   if (fileCache.has(frameId)) {
     return { frameId, fileP: fileCache.get(frameId) };
   }
   const { promise } = ReaderFactory.downloadFrame(
     apiClient,
-    'nifti.nii.gz',
+    `image${frameExtension}`,
     `/frames/${frameId}/download`,
     { onDownloadProgress },
   );
@@ -119,8 +119,8 @@ function loadFile(frameId, { onDownloadProgress = null } = {}) {
   return { frameId, fileP: promise };
 }
 
-function loadFileAndGetData(frameId, { onDownloadProgress = null } = {}) {
-  const loadResult = loadFile(frameId, { onDownloadProgress });
+function loadFileAndGetData(frameId, frameExtension, { onDownloadProgress = null } = {}) {
+  const loadResult = loadFile(frameId, frameExtension, { onDownloadProgress });
   return loadResult.fileP.then((file) => getData(frameId, file, savedWorker)
     .then(({ webWorker, frameData }) => {
       savedWorker = webWorker;
@@ -142,7 +142,7 @@ function loadFileAndGetData(frameId, { onDownloadProgress = null } = {}) {
 
 function poolFunction(webWorker, taskInfo) {
   return new Promise((resolve, reject) => {
-    const { frameId } = taskInfo;
+    const { frameId, frameExtension } = taskInfo;
 
     let filePromise = null;
 
@@ -151,7 +151,7 @@ function poolFunction(webWorker, taskInfo) {
     } else {
       const download = ReaderFactory.downloadFrame(
         apiClient,
-        'nifti.nii.gz',
+        `image${frameExtension}`,
         `/frames/${frameId}/download`,
       );
       filePromise = download.promise;
@@ -227,14 +227,17 @@ function checkLoadExperiment(oldValue, newValue) {
   readDataQueue = [];
   const newExperimentScans = store.state.experimentScans[newValue.id];
   newExperimentScans.forEach((scanId) => {
-    const scanFrames = store.state.scanFrames[scanId];
-    scanFrames.forEach((frameId) => {
+    const scanFrames = store.state.scanFrames[scanId].map(
+      (frameId) => store.state.frames[frameId]
+    );
+    scanFrames.forEach((frame) => {
       readDataQueue.push({
         // TODO don't hardcode projectId
         projectId: 1,
         experimentId: newValue.id,
         scanId,
-        frameId,
+        frameId: frame.id,
+        frameExtension: frame.extension,
       });
     });
   });
@@ -771,7 +774,7 @@ const {
         if (frameCache.has(frame.id)) {
           frameData = frameCache.get(frame.id).frameData;
         } else {
-          const result = await loadFileAndGetData(frame.id, { onDownloadProgress });
+          const result = await loadFileAndGetData(frame.id, frame.extension, { onDownloadProgress });
           frameData = result.frameData;
         }
         sourceProxy.setInputData(frameData);

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -13,6 +13,7 @@ interface Frame {
   id: string,
   name: string,
   scan: string,
+  extension: string,
 }
 
 interface ScanDecision {

--- a/client/src/utils/registerReaders.js
+++ b/client/src/utils/registerReaders.js
@@ -20,3 +20,19 @@ ReaderFactory.registerReader({
   binary: true,
   fileNameMethod: 'setFileName',
 });
+
+ReaderFactory.registerReader({
+  extension: 'nrrd',
+  name: 'NRRD Reader',
+  vtkReader: vtkITKImageReader,
+  binary: true,
+  fileNameMethod: 'setFileName',
+});
+
+ReaderFactory.registerReader({
+  extension: 'mgz',
+  name: 'MGZ Reader',
+  vtkReader: vtkITKImageReader,
+  binary: true,
+  fileNameMethod: 'setFileName',
+});

--- a/miqa/core/rest/frame.py
+++ b/miqa/core/rest/frame.py
@@ -24,10 +24,14 @@ class EvaluationSerializer(serializers.ModelSerializer):
 class FrameSerializer(serializers.ModelSerializer):
     class Meta:
         model = Frame
-        fields = ['id', 'frame_number', 'frame_evaluation']
+        fields = ['id', 'frame_number', 'frame_evaluation', 'extension']
         ref_name = 'scan_frame'
 
     frame_evaluation = EvaluationSerializer()
+    extension = serializers.SerializerMethodField('get_extension')
+
+    def get_extension(self, obj):
+        return ''.join(Path(obj.raw_path).suffixes)
 
 
 class FrameViewSet(ListModelMixin, GenericViewSet):

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -1,6 +1,7 @@
 from guardian.shortcuts import get_perms
 import pytest
 
+from miqa.core.rest.frame import FrameSerializer
 from miqa.core.rest.permissions import has_read_perm, has_review_perm
 from miqa.core.rest.scan_decision import ScanDecisionSerializer
 from miqa.core.rest.user import UserSerializer
@@ -220,13 +221,7 @@ def test_frames_list(user_api_client, frame, user):
             'count': 1,
             'next': None,
             'previous': None,
-            'results': [
-                {
-                    'id': frame.id,
-                    'frame_number': frame.frame_number,
-                    'frame_evaluation': None,
-                }
-            ],
+            'results': [FrameSerializer(frame).data],
         }
 
 


### PR DESCRIPTION
Resolves #262 

There were some places in the frontend that we used a magic filename `nifti.nii.gz` passed into the file reader, so I had to add a bit to the Frame serializer on the backend to tell us what the true file extension was.