### PR TITLE
Fix Zoom bug

### DIFF
--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -25,6 +25,7 @@ export default {
     resized: false,
     fullscreen: false,
     screenshotContainer: document.createElement('div'),
+    originalZoom: undefined,
   }),
   computed: {
     ...mapState(['proxyManager', 'loadingFrame', 'showCrosshairs', 'iIndexSlice', 'jIndexSlice', 'kIndexSlice']),
@@ -143,6 +144,7 @@ export default {
     initializeView() {
       this.view.setContainer(this.$refs.viewer);
       fill2DView(this.view);
+      this.originalZoom = this.view.getCamera().getParallelScale();
       if (this.name !== 'default') {
         this.modifiedSubscription = this.representation.onModified(() => {
           if (!this.loadingFrame) {
@@ -235,7 +237,7 @@ export default {
       });
     },
     onWindowResize() {
-      if (this.resized) {
+      if (this.resized && this.originalZoom === this.view.getCamera().getParallelScale()) {
         fill2DView(this.view);
       }
     },

--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -25,7 +25,6 @@ export default {
     resized: false,
     fullscreen: false,
     screenshotContainer: document.createElement('div'),
-    originalZoom: undefined,
   }),
   computed: {
     ...mapState(['proxyManager', 'loadingFrame', 'showCrosshairs', 'iIndexSlice', 'jIndexSlice', 'kIndexSlice']),
@@ -144,7 +143,6 @@ export default {
     initializeView() {
       this.view.setContainer(this.$refs.viewer);
       fill2DView(this.view);
-      this.originalZoom = this.view.getCamera().getParallelScale();
       if (this.name !== 'default') {
         this.modifiedSubscription = this.representation.onModified(() => {
           if (!this.loadingFrame) {
@@ -235,11 +233,6 @@ export default {
           this.resized = true;
         });
       });
-    },
-    onWindowResize() {
-      if (this.resized && this.originalZoom === this.view.getCamera().getParallelScale()) {
-        fill2DView(this.view);
-      }
     },
     changeSlice(newValue) {
       this.slice = newValue;


### PR DESCRIPTION
Resolves #277.

There are two approaches in the two below commits. The first introduces a logic in the `onWindowResize` method such that `fill2DView` is not called if the zoom level is manually set by the user. However, it may be simpler to remove this definition of the `onWindowResize` from `VtkViewer` entirely. It is unclear the original purpose for this function, because without it expected behavior is still seen. 

Could I get help determining whether it really is the case that we don't need that function anymore?