### PR TITLE
Global settings frontend

### DIFF
--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -20,7 +20,6 @@ export default defineComponent({
   setup() {
     const currentProject = computed(() => store.state.currentProject);
     const loadProject = (project: Project) => store.dispatch.loadProject(project);
-    const { isGlobal } = store.getters;
 
     const importing = ref(false);
     const importDialog = ref(false);
@@ -29,6 +28,7 @@ export default defineComponent({
     const exporting = ref(false);
 
     async function importData() {
+      const { isGlobal } = store.getters;
       importing.value = true;
       importErrorText.value = '';
       importErrors.value = false;
@@ -58,8 +58,11 @@ export default defineComponent({
       importDialog.value = false;
     }
     async function exportData() {
+      const { isGlobal } = store.getters;
       exporting.value = true;
       try {
+        console.log('global', isGlobal);
+
         if (isGlobal) {
           await djangoRest.globalExport();
         } else {
@@ -78,6 +81,7 @@ export default defineComponent({
       }
       exporting.value = false;
     }
+    const { isGlobal } = store.getters;
 
     return {
       currentProject,

--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -61,8 +61,6 @@ export default defineComponent({
       const { isGlobal } = store.getters;
       exporting.value = true;
       try {
-        console.log('global', isGlobal);
-
         if (isGlobal) {
           await djangoRest.globalExport();
         } else {

--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -40,7 +40,9 @@ export default defineComponent({
           timeout: 6000,
         });
 
-        await loadProject(currentProject.value);
+        if (currentProject.value.id !== 'global') {
+          await loadProject(currentProject.value);
+        }
       } catch (ex) {
         importing.value = false;
         this.$snackbar({
@@ -102,7 +104,7 @@ export default defineComponent({
           Import
         </v-btn>
       </template>
-      <span>Import from {{ currentProject.settings.importPath }}</span>
+      <span>Import from import path</span>
     </v-tooltip>
 
     <v-tooltip
@@ -130,7 +132,7 @@ export default defineComponent({
           </span>
         </v-btn>
       </template>
-      <span>Export to {{ currentProject.settings.exportPath }}</span>
+      <span>Export to export path</span>
     </v-tooltip>
 
     <v-dialog
@@ -142,7 +144,10 @@ export default defineComponent({
         <v-card-title class="title">
           Import
         </v-card-title>
-        <v-card-text>
+        <v-card-text v-if="currentProject.id == 'global'">
+          Importing data will overwrite all objects in every project listed in the import file.
+          Are you sure you want to overwrite all objects in multiple projects?
+        </v-card-text><v-card-text v-else>
           Importing data will overwrite all objects in this project, do you want
           to continue?
         </v-card-text>

--- a/client/src/components/ProjectSettings.vue
+++ b/client/src/components/ProjectSettings.vue
@@ -18,6 +18,7 @@ export default defineComponent({
   }),
   setup() {
     const currentProject = computed(() => store.state.currentProject);
+    const globalSettings = computed(() => store.state.globalSettings);
     const projects = computed(() => store.state.projects);
     const { isGlobal } = store.getters;
 
@@ -25,8 +26,8 @@ export default defineComponent({
     const exportPath = ref('');
     watchEffect(() => {
       if (isGlobal) {
-        importPath.value = currentProject.value.settings.importPath;
-        exportPath.value = currentProject.value.settings.exportPath;
+        importPath.value = globalSettings.value.importPath;
+        exportPath.value = globalSettings.value.exportPath;
       } else {
         djangoRest.settings(currentProject.value.id).then((settings) => {
           importPath.value = settings.importPath;
@@ -73,6 +74,7 @@ export default defineComponent({
 
     return {
       currentProject,
+      isGlobal,
       projects,
       importPath,
       exportPath,

--- a/client/src/components/ProjectSettings.vue
+++ b/client/src/components/ProjectSettings.vue
@@ -91,7 +91,7 @@ export default defineComponent({
       try {
         await djangoRest.deleteProject(this.currentProject.id);
         this.setProjects(this.projects.filter((proj) => proj.id !== this.currentProject.id));
-        this.setCurrentProject(null);
+        this.setCurrentProject(undefined);
         this.showDeleteWarningOverlay = false;
 
         this.$snackbar({

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import OAuthClient from '@girder/oauth-client';
 import {
-  Project, ProjectTaskOverview, Settings, User,
+  Project, ProjectTaskOverview, ProjectSettings, User,
 } from './types';
 import { API_URL, OAUTH_API_ROOT, OAUTH_CLIENT_ID } from './constants';
 
@@ -50,11 +50,23 @@ const djangoClient = {
     const { data } = await apiClient.get('/configuration/');
     return data;
   },
+  async globalSettings() {
+    const { data } = await apiClient.get('/global/settings')
+    return data;
+  },
   async import(projectId: string) {
-    await apiClient.post(`/projects/${projectId}/import`);
+    if( projectId === 'global' ){
+      await apiClient.post(`/global/import`);
+    } else {
+      await apiClient.post(`/projects/${projectId}/import`);
+    }
   },
   async export(projectId: string) {
-    return apiClient.post(`/projects/${projectId}/export`);
+    if( projectId === 'global' ){
+      return apiClient.post(`/global/export`);
+    } else {
+      return apiClient.post(`/projects/${projectId}/export`);
+    }
   },
   async createProject(projectName: string): Promise<Project> {
     const { data } = await apiClient.post('/projects', { name: projectName });
@@ -77,13 +89,18 @@ const djangoClient = {
     const { data } = await apiClient.get(`/projects/${projectId}/task_overview`);
     return data;
   },
-  async settings(projectId: string): Promise<Settings> {
+  async settings(projectId: string): Promise<ProjectSettings> {
     const { data } = await apiClient.get(`/projects/${projectId}/settings`);
     return data;
   },
-  async setSettings(projectId: string, settings: Settings) {
-    const resp = await apiClient.put(`/projects/${projectId}/settings`, settings);
-    return resp.status === 200 ? resp.data : null;
+  async setSettings(projectId: string, settings: ProjectSettings) {
+    if( projectId === 'global' ){
+      const resp = await apiClient.put(`/global/settings`, settings);
+      return resp.status === 200 ? resp.data : null;
+    } else {
+      const resp = await apiClient.put(`/projects/${projectId}/settings`, settings);
+      return resp.status === 200 ? resp.data : null;
+    }
   },
   async experiments(projectId: string) {
     const { data } = await apiClient.get('/experiments', {

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -51,22 +51,21 @@ const djangoClient = {
     return data;
   },
   async globalSettings() {
-    const { data } = await apiClient.get('/global/settings')
+    const { data } = await apiClient.get('/global/settings');
     return data;
   },
   async import(projectId: string) {
-    if( projectId === 'global' ){
-      await apiClient.post(`/global/import`);
+    if (projectId === 'global') {
+      await apiClient.post('/global/import');
     } else {
       await apiClient.post(`/projects/${projectId}/import`);
     }
   },
   async export(projectId: string) {
-    if( projectId === 'global' ){
-      return apiClient.post(`/global/export`);
-    } else {
-      return apiClient.post(`/projects/${projectId}/export`);
+    if (projectId === 'global') {
+      return apiClient.post('/global/export');
     }
+    return apiClient.post(`/projects/${projectId}/export`);
   },
   async createProject(projectName: string): Promise<Project> {
     const { data } = await apiClient.post('/projects', { name: projectName });
@@ -94,13 +93,12 @@ const djangoClient = {
     return data;
   },
   async setSettings(projectId: string, settings: ProjectSettings) {
-    if( projectId === 'global' ){
-      const resp = await apiClient.put(`/global/settings`, settings);
-      return resp.status === 200 ? resp.data : null;
-    } else {
-      const resp = await apiClient.put(`/projects/${projectId}/settings`, settings);
+    if (projectId === 'global') {
+      const resp = await apiClient.put('/global/settings', settings);
       return resp.status === 200 ? resp.data : null;
     }
+    const resp = await apiClient.put(`/projects/${projectId}/settings`, settings);
+    return resp.status === 200 ? resp.data : null;
   },
   async experiments(projectId: string) {
     const { data } = await apiClient.get('/experiments', {

--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -54,17 +54,16 @@ const djangoClient = {
     const { data } = await apiClient.get('/global/settings');
     return data;
   },
-  async import(projectId: string) {
-    if (projectId === 'global') {
-      await apiClient.post('/global/import');
-    } else {
-      await apiClient.post(`/projects/${projectId}/import`);
-    }
+  async globalImport() {
+    await apiClient.post('/global/import');
   },
-  async export(projectId: string) {
-    if (projectId === 'global') {
-      return apiClient.post('/global/export');
-    }
+  async projectImport(projectId: string) {
+    await apiClient.post(`/projects/${projectId}/import`);
+  },
+  async globalExport() {
+    return apiClient.post('/global/export');
+  },
+  async projectExport(projectId: string) {
     return apiClient.post(`/projects/${projectId}/export`);
   },
   async createProject(projectName: string): Promise<Project> {
@@ -92,11 +91,11 @@ const djangoClient = {
     const { data } = await apiClient.get(`/projects/${projectId}/settings`);
     return data;
   },
-  async setSettings(projectId: string, settings: ProjectSettings) {
-    if (projectId === 'global') {
-      const resp = await apiClient.put('/global/settings', settings);
-      return resp.status === 200 ? resp.data : null;
-    }
+  async setGlobalSettings(settings: ProjectSettings) {
+    const resp = await apiClient.put('/global/settings', settings);
+    return resp.status === 200 ? resp.data : null;
+  },
+  async setProjectSettings(projectId: string, settings: ProjectSettings) {
     const resp = await apiClient.put(`/projects/${projectId}/settings`, settings);
     return resp.status === 200 ? resp.data : null;
   },

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -411,8 +411,8 @@ const {
       return projectPerms;
     },
     isGlobal(state) {
-      return state.currentProject?.id === 'global'
-    }
+      return state.currentProject?.id === 'global';
+    },
   },
   mutations: {
     reset(state) {

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -568,6 +568,21 @@ const {
       dispatch('reset');
       await djangoRest.logout();
     },
+    async loadGlobal({ commit }) {
+      const globalSettings = await djangoRest.globalSettings();
+      const pseudoProject = {
+        id: 'global',
+        name: 'Global',
+        experiments: null,
+        settings: {
+          importPath: globalSettings.import_path,
+          exportPath: globalSettings.export_path,
+          permissions: null,
+        },
+        status: null
+      };
+      commit('setCurrentProject', pseudoProject)
+    },
     async loadProjects({ commit }) {
       const projects = await djangoRest.projects();
       commit('setProjects', projects);

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -579,9 +579,9 @@ const {
           exportPath: globalSettings.export_path,
           permissions: null,
         },
-        status: null
+        status: null,
       };
-      commit('setCurrentProject', pseudoProject)
+      commit('setCurrentProject', pseudoProject);
     },
     async loadProjects({ commit }) {
       const projects = await djangoRest.projects();

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -410,6 +410,9 @@ const {
       }
       return projectPerms;
     },
+    isGlobal(state) {
+      return state.currentProject?.id === 'global'
+    }
   },
   mutations: {
     reset(state) {
@@ -572,7 +575,7 @@ const {
       const globalSettings = await djangoRest.globalSettings();
       const pseudoProject = {
         id: 'global',
-        name: 'Global',
+        name: null,
         experiments: null,
         settings: {
           importPath: globalSettings.import_path,

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -52,7 +52,7 @@ interface Experiment {
 interface ProjectSettings {
   importPath: string,
   exportPath: string,
-  permissions: Object,
+  permissions?: Object,
 }
 
 enum ScanState {
@@ -81,13 +81,7 @@ interface Project {
   }
 }
 
-interface Settings {
-  importPath: string,
-  exportPath: string,
-  globalImportExport: boolean
-}
-
 export {
-  User, Project, ProjectTaskOverview,
-  Settings, ScanDecision, Frame, ScanState,
+  User, Project, ProjectTaskOverview, ProjectSettings,
+  ScanDecision, Frame, ScanState,
 };

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -34,6 +34,7 @@ export default defineComponent({
     const currentProject = computed(() => store.state.currentProject);
     const currentTaskOverview = computed(() => store.state.currentTaskOverview);
     const projects = computed(() => store.state.projects);
+    const { isGlobal } = store.getters;
     const selectedProjectIndex = ref(projects.value.findIndex(
       (project) => project.id === currentProject.value?.id,
     ));
@@ -71,6 +72,7 @@ export default defineComponent({
 
     return {
       currentProject,
+      isGlobal,
       currentTaskOverview,
       selectedProjectIndex,
       projects,
@@ -118,7 +120,7 @@ export default defineComponent({
   <div>
     <Navbar />
     <div class="d-flex">
-      <v-card style="height: calc(100vh - 50px)">
+      <v-card class="project-list-container">
         <v-navigation-drawer permanent>
           <v-card-title>Projects</v-card-title>
           <v-list-item-group
@@ -192,7 +194,7 @@ export default defineComponent({
         v-if="currentProject"
         class="flex-grow-1 ma-3 pa-5"
       >
-        <v-card-title v-if="currentProject.id === 'global'">
+        <v-card-title v-if="isGlobal">
           Perform Global Import / Export
         </v-card-title>
         <v-card-title v-else>
@@ -204,7 +206,7 @@ export default defineComponent({
             class="flex-card"
             style="flex-grow: 4;"
           >
-            <v-subheader v-if="currentProject.id === 'global'">
+            <v-subheader v-if="isGlobal">
               WARNING: Global imports will modify multiple projects.
             </v-subheader>
             <v-subheader v-else>
@@ -291,6 +293,9 @@ export default defineComponent({
   flex-grow: 1;
   margin-top: 10px;
   padding-bottom: 20px;
+}
+.project-list-container {
+  height: calc(100vh - 50px);
 }
 .project-list {
   height: calc(100% - 80px);

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -191,14 +191,14 @@ export default defineComponent({
         </v-navigation-drawer>
       </v-card>
       <div
-        v-if="currentProject"
+        v-if="currentProject !== undefined"
         class="flex-grow-1 ma-3 pa-5"
       >
         <v-card-title v-if="isGlobal">
           Perform Global Import / Export
         </v-card-title>
         <v-card-title v-else>
-          Project: {{ currentProject.name }}
+          Project: {{ currentProject ?currentProject.name :'Global' }}
         </v-card-title>
         <div class="flex-container">
           <v-card
@@ -242,14 +242,14 @@ export default defineComponent({
           class="flex-container"
         >
           <v-card
-            v-if="currentProject.experiments"
+            v-if="currentProject && currentProject.experiments"
             class="flex-card"
           >
             <v-subheader>Experiments</v-subheader>
             <ExperimentsView />
           </v-card>
           <v-card
-            v-if="currentProject.settings.permissions"
+            v-if="currentProject && currentProject.settings.permissions"
             class="flex-card"
           >
             <v-subheader>Users</v-subheader>

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -132,7 +132,10 @@ export default defineComponent({
               :key="project.id"
               @click="selectProject(project)"
             >
-              <v-tooltip right>
+              <v-tooltip
+                v-if="project.status"
+                right
+              >
                 <template v-slot:activator="{ on, attrs }">
                   <v-container
                     v-bind="attrs"

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -207,7 +207,7 @@ export default defineComponent({
             style="flex-grow: 4;"
           >
             <v-subheader v-if="isGlobal">
-              WARNING: Global imports will modify multiple projects.
+              WARNING: Global imports will modify all projects referenced in the import file.
             </v-subheader>
             <v-subheader v-else>
               Settings

--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -62,9 +62,7 @@ def validate_import_dict(import_dict, project: Optional[Project]):
         import_schema.validate(import_dict)
         import_dict = validate_file_locations(import_dict, project)
     except SchemaError:
-        import_path = (
-            GlobalSettings.load().import_path if project is None else project.import_path
-        )
+        import_path = GlobalSettings.load().import_path if project is None else project.import_path
         raise APIException(f'Invalid format of import file {import_path}')
     if not project:
         for project_name in import_dict['projects']:

--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -63,7 +63,7 @@ def validate_import_dict(import_dict, project: Optional[Project]):
         import_dict = validate_file_locations(import_dict, project)
     except SchemaError:
         import_path = (
-            GlobalSettings.load().import_path if project == 'global' else project.import_path
+            GlobalSettings.load().import_path if project is None else project.import_path
         )
         raise APIException(f'Invalid format of import file {import_path}')
     if not project:

--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from rest_framework.exceptions import APIException
 from schema import And, Schema, SchemaError, Use
 
-from miqa.core.models import Project
+from miqa.core.models import GlobalSettings, Project
+
 
 IMPORT_CSV_COLUMNS = [
     'project_name',
@@ -22,8 +23,13 @@ def validate_file_locations(input_dict, project):
         if key == 'file_location':
             raw_path = Path(value)
             if not raw_path.is_absolute():
-                # not an absolute file path; refer to project import csv location
-                raw_path = Path(project.import_path).parent.parent / raw_path
+                import_path = (
+                    GlobalSettings.load().import_path
+                    if project == 'global'
+                    else project.import_path
+                )
+                # not an absolute file path; refer to import csv location
+                raw_path = Path(import_path).parent.parent / raw_path
                 # TODO: add support for interpreting URIs not on host machine
             if not raw_path.exists():
                 raise APIException(f'Could not locate file "{raw_path}".')
@@ -33,7 +39,7 @@ def validate_file_locations(input_dict, project):
     return input_dict
 
 
-def validate_import_dict(import_dict, project: Project):
+def validate_import_dict(import_dict, project):
     import_schema = Schema(
         {
             'projects': {
@@ -56,8 +62,11 @@ def validate_import_dict(import_dict, project: Project):
         import_schema.validate(import_dict)
         import_dict = validate_file_locations(import_dict, project)
     except SchemaError:
-        raise APIException(f'Invalid format of import file {project.import_path}')
-    if project.global_import_export:
+        import_path = (
+            GlobalSettings.load().import_path if project == 'global' else project.import_path
+        )
+        raise APIException(f'Invalid format of import file {import_path}')
+    if project == 'global':
         for project_name in import_dict['projects']:
             if not Project.objects.filter(name=project_name).exists():
                 raise APIException(f'Project {project_name} does not exist')

--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -5,7 +5,6 @@ from schema import And, Schema, SchemaError, Use
 
 from miqa.core.models import GlobalSettings, Project
 
-
 IMPORT_CSV_COLUMNS = [
     'project_name',
     'experiment_name',

--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from rest_framework.exceptions import APIException
 from schema import And, Schema, SchemaError, Use
@@ -38,7 +39,7 @@ def validate_file_locations(input_dict, project):
     return input_dict
 
 
-def validate_import_dict(import_dict, project):
+def validate_import_dict(import_dict, project: Optional[Project]):
     import_schema = Schema(
         {
             'projects': {
@@ -65,7 +66,7 @@ def validate_import_dict(import_dict, project):
             GlobalSettings.load().import_path if project == 'global' else project.import_path
         )
         raise APIException(f'Invalid format of import file {import_path}')
-    if project == 'global':
+    if not project:
         for project_name in import_dict['projects']:
             if not Project.objects.filter(name=project_name).exists():
                 raise APIException(f'Project {project_name} does not exist')

--- a/miqa/core/rest/__init__.py
+++ b/miqa/core/rest/__init__.py
@@ -2,6 +2,7 @@ from .accounts import AccountActivateView, AccountInactiveView, LogoutView
 from .email import EmailView
 from .experiment import ExperimentViewSet
 from .frame import FrameViewSet
+from .global_settings import GlobalSettingsViewSet
 from .home import HomePageView
 from .other_endpoints import MIQAConfigView
 from .project import ProjectViewSet
@@ -13,6 +14,7 @@ __all__ = [
     'ExperimentViewSet',
     'HomePageView',
     'FrameViewSet',
+    'GlobalSettingsViewSet',
     'AccountActivateView',
     'AccountInactiveView',
     'LogoutView',

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -26,9 +26,9 @@ class GlobalSettingsViewSet(ViewSet):
 
     def get_permissions(self):
         if self.request.method == 'GET':
-            return [IsAuthenticated()]
+            return [IsAuthenticated]
         else:
-            return [IsSuperUser()]
+            return [IsSuperUser]
 
     @swagger_auto_schema(
         method='GET',

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -51,7 +51,7 @@ class GlobalSettingsViewSet(ViewSet):
             global_settings.export_path = request.data['exportPath']
             global_settings.full_clean()
             global_settings.save()
-        return Response(GlobalSettingsSerializer(self.get_object()).data, status=status.HTTP_200_OK)
+        return Response(GlobalSettingsSerializer(self.get_object()).data)
 
     @swagger_auto_schema(responses={204: 'Import succeeded.'})
     @action(
@@ -60,7 +60,7 @@ class GlobalSettingsViewSet(ViewSet):
         methods=['POST'],
     )
     def import_(self, request, **kwargs):
-        import_data('global')
+        import_data(None)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(responses={204: 'Export succeeded.'})
@@ -70,5 +70,5 @@ class GlobalSettingsViewSet(ViewSet):
         methods=['POST'],
     )
     def export_(self, request, **kwargs):
-        export_data('global')
+        export_data(None)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -26,9 +26,9 @@ class GlobalSettingsViewSet(ViewSet):
 
     def get_permissions(self):
         if self.request.method == 'GET':
-            return [IsAuthenticated]
+            return [IsAuthenticated()]
         else:
-            return [IsSuperUser]
+            return [IsSuperUser()]
 
     @swagger_auto_schema(
         method='GET',

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -40,12 +40,13 @@ class GlobalSettingsViewSet(ViewSet):
         methods=['GET', 'PUT'],
     )
     def settings_(self, request):
-        serializer = GlobalSettingsSerializer(self.get_object())
         if request.method == 'PUT':
-            serializer = GlobalSettingsSerializer(self.get_object(), data=request.data)
-            serializer.is_valid(raise_exception=True)
-            serializer.save()
-        return Response(serializer.data, status=status.HTTP_200_OK)
+            global_settings = self.get_object()
+            global_settings.import_path = request.data['importPath']
+            global_settings.export_path = request.data['exportPath']
+            global_settings.full_clean()
+            global_settings.save()
+        return Response(GlobalSettingsSerializer(self.get_object()).data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(responses={204: 'Import succeeded.'})
     @action(

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -1,12 +1,17 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from miqa.core.models import GlobalSettings
 from miqa.core.tasks import export_data, import_data
+
+
+class IsSuperUser(BasePermission):
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_superuser)
 
 
 class GlobalSettingsSerializer(serializers.ModelSerializer):
@@ -23,7 +28,7 @@ class GlobalSettingsViewSet(ViewSet):
         if self.request.method == 'GET':
             return [IsAuthenticated()]
         else:
-            return [IsAdminUser()]
+            return [IsSuperUser()]
 
     @swagger_auto_schema(
         method='GET',

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -1,0 +1,68 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers, status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from miqa.core.models import GlobalSettings
+from miqa.core.tasks import export_data, import_data
+
+
+class GlobalSettingsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GlobalSettings
+        exclude = ['id']
+
+
+class GlobalSettingsViewSet(ViewSet):
+    def get_object(self):
+        return GlobalSettings.load()
+
+    def get_permissions(self):
+        if self.request.method == 'GET':
+            return [IsAuthenticated()]
+        else:
+            return [IsAdminUser()]
+
+    @swagger_auto_schema(
+        method='GET',
+        responses={200: GlobalSettingsSerializer()},
+    )
+    @swagger_auto_schema(
+        method='PUT',
+        request_body=GlobalSettingsSerializer(),
+        responses={200: GlobalSettingsSerializer()},
+    )
+    @action(
+        detail=False,
+        url_path='settings',
+        methods=['GET', 'PUT'],
+    )
+    def settings_(self, request):
+        serializer = GlobalSettingsSerializer(self.get_object())
+        if request.method == 'PUT':
+            serializer = GlobalSettingsSerializer(self.get_object(), data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(responses={204: 'Import succeeded.'})
+    @action(
+        detail=False,
+        url_path='import',
+        methods=['POST'],
+    )
+    def import_(self, request, **kwargs):
+        import_data('global')
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @swagger_auto_schema(responses={204: 'Export succeeded.'})
+    @action(
+        detail=False,
+        url_path='export',
+        methods=['POST'],
+    )
+    def export_(self, request, **kwargs):
+        export_data('global')
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/miqa/core/rest/global_settings.py
+++ b/miqa/core/rest/global_settings.py
@@ -45,13 +45,13 @@ class GlobalSettingsViewSet(ViewSet):
         methods=['GET', 'PUT'],
     )
     def settings_(self, request):
+        global_settings = self.get_object()
         if request.method == 'PUT':
-            global_settings = self.get_object()
             global_settings.import_path = request.data['importPath']
             global_settings.export_path = request.data['exportPath']
             global_settings.full_clean()
             global_settings.save()
-        return Response(GlobalSettingsSerializer(self.get_object()).data)
+        return Response(GlobalSettingsSerializer(global_settings).data)
 
     @swagger_auto_schema(responses={204: 'Import succeeded.'})
     @action(

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -175,7 +175,6 @@ class ProjectViewSet(
 
             project.import_path = request.data['importPath']
             project.export_path = request.data['exportPath']
-            project.global_import_export = request.data['globalImportExport']
             project.full_clean()
             project.save()
         serializer = ProjectSettingsSerializer(project)

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -191,7 +191,7 @@ class ProjectViewSet(
         project: Project = self.get_object()
 
         # tasks sent to celery must use serializable arguments
-        import_data(request.user.id, project.id)
+        import_data(project.id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -16,11 +16,10 @@ from miqa.core.tasks import export_data, import_data
 class ProjectSettingsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
-        fields = ['importPath', 'exportPath', 'globalImportExport', 'permissions']
+        fields = ['importPath', 'exportPath', 'permissions']
 
     importPath = serializers.CharField(source='import_path')  # noqa: N815
     exportPath = serializers.CharField(source='export_path')  # noqa: N815
-    globalImportExport = serializers.BooleanField(source='global_import_export')  # noqa: N815
     permissions = serializers.SerializerMethodField('get_permissions')
 
     def get_permissions(self, obj):

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -72,7 +72,7 @@ def perform_import(import_dict, project_id: Optional[str]):
     new_frames = []
 
     for project_name, project_data in import_dict['projects'].items():
-        if not project_id:
+        if project_id is None:
             # A global import uses the project name column to determine which project to import to
             project_object = Project.objects.get(name=project_name)
         else:

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -46,7 +46,7 @@ def evaluate_data(frames_by_project):
 
 
 def import_data(project_id: Optional[str]):
-    if not project_id:
+    if project_id is None:
         project = None
         import_path = GlobalSettings.load().import_path
     else:

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -56,7 +56,8 @@ def import_data(project_id: Optional[str]):
     if import_path.endswith('.csv'):
         import_dict = import_dataframe_to_dict(pandas.read_csv(import_path))
     elif import_path.endswith('.json'):
-        import_dict = json.load(open(import_path))
+        with open(import_path) as import_fd:
+            import_dict = json.load(import_fd)
     else:
         raise APIException(f'Invalid import file {import_path}. Must be CSV or JSON.')
 

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Optional
 
 from celery import shared_task
 import pandas
@@ -44,9 +45,9 @@ def evaluate_data(frames_by_project):
         )
 
 
-def import_data(project_id):
-    if project_id == 'global':
-        project = 'global'
+def import_data(project_id: Optional[str]):
+    if not project_id:
+        project = None
         import_path = GlobalSettings.load().import_path
     else:
         project = Project.objects.get(id=project_id)
@@ -64,14 +65,14 @@ def import_data(project_id):
 
 
 @shared_task
-def perform_import(import_dict, project_id):
+def perform_import(import_dict, project_id: Optional[str]):
     new_projects = []
     new_experiments = []
     new_scans = []
     new_frames = []
 
     for project_name, project_data in import_dict['projects'].items():
-        if project_id == 'global':
+        if not project_id:
             # A global import uses the project name column to determine which project to import to
             project_object = Project.objects.get(name=project_name)
         else:
@@ -116,8 +117,8 @@ def perform_import(import_dict, project_id):
     evaluate_data.delay(frames_by_project)
 
 
-def export_data(project_id):
-    if project_id == 'global':
+def export_data(project_id: Optional[str]):
+    if not project_id:
         export_path = GlobalSettings.load().export_path
     else:
         project = Project.objects.get(id=project_id)
@@ -130,10 +131,10 @@ def export_data(project_id):
 
 
 @shared_task
-def perform_export(project_id):
+def perform_export(project_id: Optional[str]):
     data = []
 
-    if project_id == 'global':
+    if not project_id:
         # A global export should export all projects
         projects = Project.objects.all()
         export_path = GlobalSettings.load().export_path

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -11,22 +11,22 @@ from miqa.core.conversion.import_export_csvs import (
     validate_import_dict,
 )
 from miqa.core.conversion.nifti_to_zarr_ngff import nifti_to_zarr_ngff
-from miqa.core.models import Evaluation, Experiment, Frame, Project, Scan
+from miqa.core.models import Evaluation, Experiment, Frame, GlobalSettings, Project, Scan
 from miqa.learning.evaluation_models import available_evaluation_models
 from miqa.learning.nn_inference import evaluate_many
 
 
 @shared_task
-def evaluate_data(frame_ids, project_id):
-    frames = Frame.objects.filter(pk__in=frame_ids)
-    project = Project.objects.get(id=project_id)
-
+def evaluate_data(frames_by_project):
     model_to_frames_map = {}
-    for frame in frames:
-        eval_model_name = project.evaluation_models[[frame.scan.scan_type][0]]
-        if eval_model_name not in model_to_frames_map:
-            model_to_frames_map[eval_model_name] = []
-        model_to_frames_map[eval_model_name].append(frame)
+    for project_id, frame_ids in frames_by_project.items():
+        project = Project.objects.get(id=project_id)
+        for frame_id in frame_ids:
+            frame = Frame.objects.get(id=frame_id)
+            eval_model_name = project.evaluation_models[[frame.scan.scan_type][0]]
+            if eval_model_name not in model_to_frames_map:
+                model_to_frames_map[eval_model_name] = []
+            model_to_frames_map[eval_model_name].append(frame)
 
     for model_name, frame_set in model_to_frames_map.items():
         current_model = available_evaluation_models[model_name].load()
@@ -44,15 +44,20 @@ def evaluate_data(frame_ids, project_id):
         )
 
 
-def import_data(user_id, project_id):
-    project = Project.objects.get(id=project_id)
-
-    if project.import_path.endswith('.csv'):
-        import_dict = import_dataframe_to_dict(pandas.read_csv(project.import_path))
-    elif project.import_path.endswith('.json'):
-        import_dict = json.load(open(project.import_path))
+def import_data(project_id):
+    if project_id == 'global':
+        project = 'global'
+        import_path = GlobalSettings.load().import_path
     else:
-        raise APIException(f'Invalid import file {project.import_path}.')
+        project = Project.objects.get(id=project_id)
+        import_path = project.import_path
+
+    if import_path.endswith('.csv'):
+        import_dict = import_dataframe_to_dict(pandas.read_csv(import_path))
+    elif import_path.endswith('.json'):
+        import_dict = json.load(open(import_path))
+    else:
+        raise APIException(f'Invalid import file {import_path}. Must be CSV or JSON.')
 
     import_dict = validate_import_dict(import_dict, project)
     perform_import.delay(import_dict, project_id)
@@ -65,17 +70,13 @@ def perform_import(import_dict, project_id):
     new_scans = []
     new_frames = []
 
-    # comment out the below line and remove project_id param
-    # when multi-project imports are supported
-    project = Project.objects.get(id=project_id)
-
     for project_name, project_data in import_dict['projects'].items():
-        if project.global_import_export:
+        if project_id == 'global':
             # A global import uses the project name column to determine which project to import to
             project_object = Project.objects.get(name=project_name)
         else:
             # A normal import ignores the project name column
-            project_object = project
+            project_object = Project.objects.get(id=project_id)
 
         # delete old imports of these projects
         Experiment.objects.filter(
@@ -106,41 +107,41 @@ def perform_import(import_dict, project_id):
     Scan.objects.bulk_create(new_scans)
     Frame.objects.bulk_create(new_frames)
 
-    evaluate_data.delay([frame.id for frame in new_frames], project.id)
+    frames_by_project = {}
+    for frame in new_frames:
+        project_id = str(frame.scan.experiment.project.id)
+        if project_id not in frames_by_project:
+            frames_by_project[project_id] = []
+        frames_by_project[project_id].append(str(frame.id))
+    evaluate_data.delay(frames_by_project)
 
 
 def export_data(project_id):
-    project = Project.objects.get(id=project_id)
-    parent_location = Path(project.export_path).parent
+    if project_id == 'global':
+        export_path = GlobalSettings.load().export_path
+    else:
+        project = Project.objects.get(id=project_id)
+        export_path = project.export_path
+    parent_location = Path(export_path).parent
     if not parent_location.exists():
         raise APIException(f'No such location {parent_location} to create export file.')
 
-    # In the event of a global export, we only want to export the projects listed in the import
-    # file. Read the import file now and extract the project names.
-    if project.import_path.endswith('.csv'):
-        import_dict = import_dataframe_to_dict(pandas.read_csv(project.import_path))
-    elif project.import_path.endswith('.json'):
-        import_dict = json.load(open(project.import_path))
-    else:
-        raise APIException(f'Invalid import file {project.import_path}.')
-
-    import_dict = validate_import_dict(import_dict, project)
-    project_names = import_dict['projects'].keys()
-
-    perform_export.delay(project_id, project_names)
+    perform_export.delay(project_id)
 
 
 @shared_task
-def perform_export(project_id, project_names):
-    project = Project.objects.get(id=project_id)
+def perform_export(project_id):
     data = []
 
-    if project.global_import_export:
-        # A global export should export all projects listed in the import file
-        projects = [Project.objects.get(name=project_name) for project_name in project_names]
+    if project_id == 'global':
+        # A global export should export all projects
+        projects = Project.objects.all()
+        export_path = GlobalSettings.load().export_path
     else:
         # A normal export should only export the current project
+        project = Project.objects.get(id=project_id)
         projects = [project]
+        export_path = project.export_path
 
     for project_object in projects:
         for frame_object in Frame.objects.filter(scan__experiment__project=project_object):
@@ -155,4 +156,4 @@ def perform_export(project_id, project_names):
                 ]
             )
     export_df = pandas.DataFrame(data, columns=IMPORT_CSV_COLUMNS)
-    export_df.to_csv(project_object.export_path, index=False)
+    export_df.to_csv(export_path, index=False)

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -111,10 +111,10 @@ def perform_import(import_dict, project_id: Optional[str]):
 
     frames_by_project = {}
     for frame in new_frames:
-        project_id = str(frame.scan.experiment.project.id)
+        project_id = frame.scan.experiment.project.id
         if project_id not in frames_by_project:
             frames_by_project[project_id] = []
-        frames_by_project[project_id].append(str(frame.id))
+        frames_by_project[project_id].append(frame.id)
     evaluate_data.delay(frames_by_project)
 
 

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -134,7 +134,7 @@ def export_data(project_id: Optional[str]):
 def perform_export(project_id: Optional[str]):
     data = []
 
-    if not project_id:
+    if project_id is None:
         # A global export should export all projects
         projects = Project.objects.all()
         export_path = GlobalSettings.load().export_path

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -37,9 +37,8 @@ def test_project_settings_get(user_api_client, project, user):
         assert all(key in resp.data for key in ['importPath', 'exportPath', 'permissions'])
 
 
-@pytest.mark.parametrize('global_import_export', [True, False])
 @pytest.mark.django_db
-def test_project_settings_put(user_api_client, project, user, global_import_export):
+def test_project_settings_put(user_api_client, project, user):
     user_api_client = user_api_client()
     my_perms = get_perms(user, project)
     new_perms = {
@@ -52,7 +51,6 @@ def test_project_settings_put(user_api_client, project, user, global_import_expo
         data={
             'importPath': '/new/fake/path',
             'exportPath': '/new/fake/path',
-            'globalImportExport': global_import_export,
             'permissions': new_perms,
         },
     )
@@ -74,7 +72,6 @@ def test_project_settings_put(user_api_client, project, user, global_import_expo
         assert user_api_client.get(f'/api/v1/projects/{project.id}/settings').data == {
             'importPath': '/new/fake/path',
             'exportPath': '/new/fake/path',
-            'globalImportExport': global_import_export,
             'permissions': expected_perms,
         }
         my_new_perms = get_perms(user, project)
@@ -91,7 +88,6 @@ def test_settings_endpoint_requires_superuser(user_api_client, project, user):
         data={
             'importPath': '/new/fake/path',
             'exportPath': '/new/fake/path',
-            'globalImportExport': False,
             'permissions': {},
         },
     )

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -27,7 +27,7 @@ router.register('experiments', ExperimentViewSet, basename='experiment')
 router.register('scans', ScanViewSet, basename='scan')
 router.register('frames', FrameViewSet, basename='frame')
 router.register('scan-decisions', ScanDecisionViewSet, basename='scan_decisions')
-router.register('global', GlobalSettingsViewSet, basename="global")
+router.register('global', GlobalSettingsViewSet, basename='global')
 router.register('users', UserViewSet)
 
 # OpenAPI generation

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -11,6 +11,7 @@ from miqa.core.rest import (
     EmailView,
     ExperimentViewSet,
     FrameViewSet,
+    GlobalSettingsViewSet,
     HomePageView,
     LogoutView,
     MIQAConfigView,
@@ -26,6 +27,7 @@ router.register('experiments', ExperimentViewSet, basename='experiment')
 router.register('scans', ScanViewSet, basename='scan')
 router.register('frames', FrameViewSet, basename='frame')
 router.register('scan-decisions', ScanDecisionViewSet, basename='scan_decisions')
+router.register('global', GlobalSettingsViewSet, basename="global")
 router.register('users', UserViewSet)
 
 # OpenAPI generation


### PR DESCRIPTION
This PR introduces four new endpoints to accompany the `GlobalSettings` singleton model:

1. GET /global/settings
2. PUT /global/settings
3. POST /global/import
4. POST /global/export

Additionally, this PR leverages those endpoints on the frontend to include an admin-only UI for editing the values of th global import path and export path, as well as performing global imports/exports