### PR TITLE
Fix place crosshairs

### DIFF
--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -25,6 +25,11 @@ export default {
     resized: false,
     fullscreen: false,
     screenshotContainer: document.createElement('div'),
+    ijkMapping: {
+      x: 'i',
+      y: 'j',
+      z: 'k',
+    },
   }),
   computed: {
     ...mapState(['proxyManager',
@@ -62,12 +67,7 @@ export default {
       }
     },
     ijkName() : ('i' | 'j' | 'k') {
-      const ijkMapping = {
-        x: 'i',
-        y: 'j',
-        z: 'k',
-      };
-      return ijkMapping[this.name];
+      return this.ijkMapping[this.name];
     },
     keyboardBindings() {
       switch (this.name) {
@@ -86,13 +86,8 @@ export default {
     slice(value) {
       this.representation.setSlice(value);
       if (this.setCurrentVtkIndexSlices) {
-        const ijkMapping = {
-          x: 'i',
-          y: 'j',
-          z: 'k',
-        };
         this.setCurrentVtkIndexSlices({
-          indexAxis: ijkMapping[this.trueAxis(this.name)],
+          indexAxis: this.ijkMapping[this.trueAxis(this.name)],
           value: this.representation.getSliceIndex(),
         });
       }
@@ -118,6 +113,7 @@ export default {
       oldView.setContainer(null);
       this.initializeSlice();
       this.initializeView();
+      view.getInteractor().onLeftButtonPress((event) => this.placeCrosshairs(event));
     },
     currentFrame() {
       this.representation.setSlice(this.slice);

--- a/client/src/components/VtkViewer.vue
+++ b/client/src/components/VtkViewer.vue
@@ -306,7 +306,6 @@ export default {
         this.iIndexSlice, this.jIndexSlice, this.kIndexSlice,
       );
       const location = crosshairSet.locationOfClick(clickEvent);
-      location[this.ijkName] = this.representation.getSliceIndex();
       this.setSliceLocation(location);
     },
     cleanup() {


### PR DESCRIPTION
During yesterday's demo, I realized that the version that fixed rotated images broke axis-swapped images. This fix works for both.