### PR TITLE
Allow anyone with project access to import/export

### DIFF
--- a/client/src/components/ProjectSettings.vue
+++ b/client/src/components/ProjectSettings.vue
@@ -153,6 +153,7 @@ export default defineComponent({
     <v-layout>
       <v-switch
         v-model="globalImportExport"
+        :disabled="!user.is_superuser"
         @click="changed = true"
         color="primary"
         label="Global import/export"
@@ -186,7 +187,7 @@ export default defineComponent({
           </v-btn>
         </v-col>
         <v-col cols="9">
-          <DataImportExport v-if="user.is_superuser" />
+          <DataImportExport />
         </v-col>
         <v-col
           cols="2"

--- a/client/src/views/Projects.vue
+++ b/client/src/views/Projects.vue
@@ -180,7 +180,6 @@ export default defineComponent({
         <v-card-title>Project: {{ currentProject.name }}</v-card-title>
         <div class="flex-container">
           <v-card
-            v-if="user.is_superuser"
             class="flex-card"
             style="flex-grow: 4;"
           >

--- a/miqa/core/rest/project.py
+++ b/miqa/core/rest/project.py
@@ -172,7 +172,7 @@ class ProjectViewSet(
         request_body=no_body,
         responses={204: 'Import succeeded.'},
     )
-    @project_permission_required(superuser_access=True)
+    @project_permission_required()
     @action(detail=True, url_path='import', url_name='import', methods=['POST'])
     def import_(self, request, **kwargs):
         project: Project = self.get_object()

--- a/miqa/core/tests/test_import.py
+++ b/miqa/core/tests/test_import.py
@@ -4,9 +4,9 @@ import json
 from pathlib import Path
 import re
 
+from guardian.shortcuts import get_perms
 import pytest
 from rest_framework.exceptions import APIException
-from guardian.shortcuts import get_perms
 
 from miqa.core.tasks import import_data
 

--- a/miqa/core/tests/test_import.py
+++ b/miqa/core/tests/test_import.py
@@ -6,6 +6,7 @@ import re
 
 import pytest
 from rest_framework.exceptions import APIException
+from guardian.shortcuts import get_perms
 
 from miqa.core.tasks import import_data
 
@@ -86,7 +87,7 @@ def test_import_csv(tmp_path, user, project_factory, sample_scans, user_api_clie
     user_api_client = user_api_client(project=project)
 
     resp = user_api_client.post(f'/api/v1/projects/{project.id}/import')
-    if user.is_superuser:
+    if get_perms(user, project):
         assert resp.status_code == 204
         # The import should update the project, even though the names do not match
         project.refresh_from_db()
@@ -115,7 +116,7 @@ def test_import_global_csv(tmp_path, user, project_factory, sample_scans, user_a
     user_api_client = user_api_client(project=project)
 
     resp = user_api_client.post(f'/api/v1/projects/{project.id}/import')
-    if user.is_superuser:
+    if get_perms(user, project):
         assert resp.status_code == 204
         # The import should update the correctly named projects, but not the original import project
         project.refresh_from_db()
@@ -147,7 +148,7 @@ def test_import_json(
     project = project_factory(import_path=json_file)
 
     resp = user_api_client(project=project).post(f'/api/v1/projects/{project.id}/import')
-    if user.is_superuser:
+    if get_perms(user, project):
         assert resp.status_code == 204
         # The import should update the project, even though the names do not match
         project.refresh_from_db()
@@ -181,7 +182,7 @@ def test_import_global_json(
     user_api_client = user_api_client(project=project)
 
     resp = user_api_client.post(f'/api/v1/projects/{project.id}/import')
-    if user.is_superuser:
+    if get_perms(user, project):
         assert resp.status_code == 204
         # The import should update the correctly named projects, but not the original import project
         project.refresh_from_db()


### PR DESCRIPTION
Anyone with project access now is able to click the import/export buttons. They are not allowed to change import/export paths or the global import setting.