### PR TITLE
Fix timeout

### DIFF
--- a/client/src/components/Navbar.vue
+++ b/client/src/components/Navbar.vue
@@ -118,7 +118,6 @@ export default defineComponent({
         v-model="emailDialog"
         :notes="notes"
       />
-      <TimeoutDialog />
     </div>
 
     <UserAvatar :target-user="user" />
@@ -126,6 +125,7 @@ export default defineComponent({
       @user="logoutUser()"
       @login="djangoRest.login()"
     />
+    <TimeoutDialog />
   </v-app-bar>
 </template>
 

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -118,7 +118,7 @@ export default {
           back in
         </p>
         <p v-else>
-          You have been inactive for more than 1 hour. Your session will
+          You have been inactive for more than 30 minutes. Your session will
           automatically terminate in {{ minutesStr }} {{ secondsStr }}
         </p>
       </v-card-text>

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -118,7 +118,7 @@ export default {
           back in
         </p>
         <p v-else>
-          You have been inactive for more than 30 minutes. Your session will
+          You have been inactive for almost 30 minutes. Your session will
           automatically terminate in {{ minutesStr }} {{ secondsStr }}
         </p>
       </v-card-text>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -33,7 +33,7 @@ const poolSize = Math.floor(navigator.hardwareConcurrency / 2) || 2;
 let taskRunId = -1;
 let savedWorker = null;
 
-const actiontime = 1800000; // 30 minute no action timeout
+const actiontime = 28 * 60 * 1000; // 28 minute no action timeout + 2 minutes to take action
 
 function shrinkProxyManager(proxyManager) {
   proxyManager.getViews().forEach((view) => {


### PR DESCRIPTION
* Move `TimeoutDialog` so it always loads instead of only showing up on the Frame view.
* Adjust some timing and messaging for a cleaner UX.