### PR TITLE
Base64 decode images in email content

### DIFF
--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -1,3 +1,4 @@
+from base64 import b64decode
 from email.mime.image import MIMEImage
 import mimetypes
 import re
@@ -30,9 +31,10 @@ class EmailView(APIView):
             )
 
             if match:
-
+                b64_data = match.group('data')
+                data = b64decode(b64_data)
                 mime = match.group('mime')
-                img = MIMEImage(match.group('data'), mime.split('/')[1])
+                img = MIMEImage(data, mime.split('/')[1])
                 img.add_header('Content-Id', f'<file{index}>')
                 img.add_header(
                     'Content-Disposition',


### PR DESCRIPTION
Screenshots via email are currently broken. They are arriving base64-encoded.