### PR TITLE
Suggested changes to default email recipients feature

### DIFF
--- a/client/src/components/EmailDialog.vue
+++ b/client/src/components/EmailDialog.vue
@@ -81,22 +81,22 @@ export default defineComponent({
         return;
       }
       this.selectedScreenshots = [];
-      this.toCandidates = [];
-      this.ccCandidates = this.currentProject.settings.default_email_recipients.map(
+      this.toCandidates = this.currentProject.settings.default_email_recipients.map(
         (emailString) => ({
           name: emailString,
         }),
       );
+      this.ccCandidates = [];
       this.bccCandidates = [];
       this.to = this.toCandidates.map((c) => c.name);
       this.cc = this.ccCandidates.map((c) => c.name);
       this.bcc = this.bccCandidates.map((c) => c.name);
       if (this.user) {
-        this.bcc.push(this.user.email);
+        this.cc.push(this.user.email);
       }
       this.showCC = !!this.cc.length;
       this.showBCC = !!this.bcc.length;
-      this.subject = `Regarding ${this.currentViewData.experimentName}, ${this.currentScan.name}`;
+      this.subject = `Regarding ${this.currentViewData.projectName}, ${this.currentViewData.experimentName}, ${this.currentScan.name}`;
       this.body = `Experiment: ${this.currentViewData.experimentName}\nScan: ${this.currentScan.name}\n`;
       if (this.currentViewData.scanDecisions.length > 0) {
         this.body += `Decisions:\n ${this.currentViewData.scanDecisions.map(

--- a/client/src/components/EmailDialog.vue
+++ b/client/src/components/EmailDialog.vue
@@ -44,9 +44,6 @@ export default defineComponent({
     to: [],
     cc: [],
     bcc: [],
-    toCandidates: [],
-    ccCandidates: [],
-    bccCandidates: [],
     showCC: false,
     showBCC: false,
     subject: '',
@@ -81,16 +78,9 @@ export default defineComponent({
         return;
       }
       this.selectedScreenshots = [];
-      this.toCandidates = this.currentProject.settings.default_email_recipients.map(
-        (emailString) => ({
-          name: emailString,
-        }),
-      );
-      this.ccCandidates = [];
-      this.bccCandidates = [];
-      this.to = this.toCandidates.map((c) => c.name);
-      this.cc = this.ccCandidates.map((c) => c.name);
-      this.bcc = this.bccCandidates.map((c) => c.name);
+      this.to = this.currentProject.settings.default_email_recipients;
+      this.cc = [];
+      this.bcc = [];
       if (this.user) {
         this.cc.push(this.user.email);
       }
@@ -118,23 +108,11 @@ export default defineComponent({
       if (!this.$refs.form.validate()) {
         return;
       }
-      const toAddresses = this.to.map((recipient) => {
-        const candidate = this.toCandidates.find((c) => c.name === recipient);
-        return candidate ? candidate.email : recipient;
-      });
-      const ccAddresses = this.cc.map((recipient) => {
-        const candidate = this.ccCandidates.find((c) => c.name === recipient);
-        return candidate ? candidate.email : recipient;
-      });
-      const bccAddresses = this.bcc.map((recipient) => {
-        const candidate = this.bccCandidates.find((c) => c.name === recipient);
-        return candidate ? candidate.email : recipient;
-      });
       this.sending = true;
       await djangoRest.sendEmail({
-        to: toAddresses,
-        cc: ccAddresses,
-        bcc: bccAddresses,
+        to: this.to,
+        cc: this.cc,
+        bcc: this.bcc,
         subject: this.subject,
         body: this.body,
         screenshots: this.screenshots.filter(
@@ -193,7 +171,7 @@ export default defineComponent({
             <v-flex>
               <EmailRecipientCombobox
                 v-model="to"
-                :candidates="toCandidates.map(c => c.name)"
+                :candidates="to"
                 :required="true"
                 label="to"
               />
@@ -215,7 +193,7 @@ export default defineComponent({
             <v-flex>
               <EmailRecipientCombobox
                 v-model="cc"
-                :candidates="ccCandidates.map(c => c.name)"
+                :candidates="cc"
                 :required="false"
                 label="cc"
               />
@@ -225,7 +203,7 @@ export default defineComponent({
             <v-flex>
               <EmailRecipientCombobox
                 v-model="bcc"
-                :candidates="bccCandidates.map(c => c.name)"
+                :candidates="bcc"
                 :required="false"
                 label="bcc"
               />

--- a/client/src/components/ProjectUsers.vue
+++ b/client/src/components/ProjectUsers.vue
@@ -46,10 +46,14 @@ export default {
       return JSON.stringify(this.permissions)
         !== JSON.stringify(this.selectedPermissionSet);
     },
+    userCanEditProject() {
+      return this.user.is_superuser || this.user.username === this.currentProject.value.creator;
+    },
   },
   watch: {
     currentProject(newProj) {
       this.selectedPermissionSet = { ...newProj.settings.permissions };
+      this.emailList = this.currentProject.settings.default_email_recipients;
     },
   },
   mounted() {
@@ -128,7 +132,7 @@ export default {
         <v-col cols="12">
           Members
           <v-tooltip
-            v-if="user.is_superuser || user.username == currentProject.creator"
+            v-if="userCanEditProject"
             bottom
             style="display: inline; padding-left: 5px"
           >
@@ -169,7 +173,7 @@ export default {
         <v-col cols="12">
           Collaborators <span class="gray-info">(Read only)</span>
           <v-tooltip
-            v-if="user.is_superuser || user.username == currentProject.creator"
+            v-if="userCanEditProject"
             bottom
             style="display: inline; padding-left: 5px"
           >
@@ -207,7 +211,6 @@ export default {
         <v-col cols="12">
           Default email recipients
           <v-tooltip
-            v-if="user.is_superuser || user.username == currentProject.creator"
             bottom
             style="display: inline; padding-left: 5px"
           >
@@ -233,6 +236,7 @@ export default {
           <v-combobox
             v-model="emailList"
             :items="emailOptions"
+            :disabled="!userCanEditProject"
             label="Select or type an email"
             :rules="[allEmails]"
             multiple
@@ -242,12 +246,14 @@ export default {
             style="max-width:500px;"
           >
             <template #append-outer>
-              <v-icon
-                v-if="emailListChanged"
+              <v-btn
+                v-if="userCanEditProject"
+                :disabled="!emailListChanged"
+                color="primary"
                 @click="saveEmails"
               >
-                save
-              </v-icon>
+                Save
+              </v-btn>
             </template>
           </v-combobox>
         </v-col>

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -20,6 +20,7 @@ class EmailView(APIView):
             request.data['to'],
             bcc=request.data['bcc'],
             cc=request.data['cc'],
+            reply_to=[request.user.email],
         )
 
         for index, screenshot in enumerate(request.data['screenshots']):


### PR DESCRIPTION
The changes suggested during this morning's meeting were as follows:

- move the default recipients from 'cc' to 'to'
- move self recipient from 'bcc' to 'cc'
- add the project name to email subjects
- make the save button next to the default email recipients input the same as the save button for the import and export paths
- value in default email recipients input should refresh upon switching projects
- default email recipients input should be disabled for users that are neither a superuser nor the project creator