### PR TITLE
Update files in prod directory

### DIFF
--- a/prod/.env.template
+++ b/prod/.env.template
@@ -16,7 +16,7 @@ MIQA_SERVER_PORT=8000
 DJANGO_MIQA_URL_PREFIX=/
 # This specifies the directory to be mounted so the app can perform imports.
 # It will be mounted at the same location in the container.
-MIQA_MOUNT_DIR=/usr/var/local/miqa
+SAMPLES_DIR=./samples
 DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/
 
 # Do not change the settings below this line

--- a/prod/README.md
+++ b/prod/README.md
@@ -118,9 +118,10 @@ Now that data is ingested into your Project, you may now also click the "Export"
 # Updating the deployment
 To non-destructively update your instance at any time:
 1. Pull changes from github.
-2. Run `docker-compose pull`
-3. Run `docker-compose build --pull --no-cache`
-4. Run `docker-compose run --rm django ./manage.py migrate`
-5. Run `docker-compose up -d`
+2. Run `git lfs fetch && git lfs pull`
+3. Run `docker-compose pull`
+4. Run `docker-compose build --pull --no-cache`
+5. Run `docker-compose run --rm django ./manage.py migrate`
+6. Run `docker-compose up -d`
 
 Visit `https://miqa.local/admin/` for any admin configuration that needs to be done.

--- a/prod/README.md
+++ b/prod/README.md
@@ -117,11 +117,10 @@ Now that data is ingested into your Project, you may now also click the "Export"
 
 # Updating the deployment
 To non-destructively update your instance at any time:
-1. Pull changes from github.
-2. Run `git lfs fetch && git lfs pull`
-3. Run `docker-compose pull`
-4. Run `docker-compose build --pull --no-cache`
-5. Run `docker-compose run --rm django ./manage.py migrate`
-6. Run `docker-compose up -d`
+1. Run `git lfs checkout <release_tag>`
+2. Run `docker-compose pull`
+3. Run `docker-compose build --pull --no-cache`
+4. Run `docker-compose run --rm django ./manage.py migrate`
+5. Run `docker-compose up -d`
 
 Visit `https://miqa.local/admin/` for any admin configuration that needs to be done.

--- a/prod/django.Dockerfile
+++ b/prod/django.Dockerfile
@@ -26,10 +26,10 @@ ARG DJANGO_MIQA_URL_PREFIX
 ARG DJANGO_SECRET_KEY
 COPY ./setup.py /opt/django-project/setup.py
 COPY ./manage.py /opt/django-project/manage.py
-COPY ./miqa /opt/django-project/miqa
 WORKDIR /opt/django-project/
 RUN pip install .[learning] && \
     ./manage.py collectstatic
+COPY ./miqa /opt/django-project/miqa
 
 # Web client:
 # * Build

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     #           capabilities: [gpu]
     env_file: ./.env
     volumes:
-      - "${MIQA_MOUNT_DIR}:${MIQA_MOUNT_DIR}"
+      - ${SAMPLES_DIR}:${SAMPLES_DIR}
     ports:
       - ${MIQA_SERVER_PORT}:8000
     depends_on:
@@ -72,7 +72,7 @@ services:
     tty: false
     env_file: ./.env
     volumes:
-      - "${MIQA_MOUNT_DIR}:${MIQA_MOUNT_DIR}"
+      - ${SAMPLES_DIR}:${SAMPLES_DIR}
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
After working with Jim to fix his deployment's evaluations, we found some points for improvement in the files in the `prod` directory to make things clearer/faster for those putting up production instances.

1. In the prod README, change the "update from git" instruction explicitly use git lfs (the problem on Jim's machine appeared to be that checking out the release tag set the model files back to their placeholder-file state, so our instructions for updating the deployment should make use of `git lfs checkout ...`)
2. In the prod Dockerfile, reorder the commands so that pip installations don't happen unless the requirements have changed (makes for faster builds)
3. Make the use of the `SAMPLES_DIR` env variable more clear in the template and docker compose so future deployers are not confused about which directory to supply to this variable