### PR TITLE
Allow direct API authorization

### DIFF
--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -17,12 +17,12 @@ def test_api_token_access(user, api_client):
     resp_1 = api_client.post(
         '/api-token-auth/',
         data={
-            "username": user.username,
-            "password": password,
+            'username': user.username,
+            'password': password,
         },
     )
     assert resp_1.status_code == 200
-    token = resp_1.json()["token"]
+    token = resp_1.json()['token']
 
     resp_2 = api_client.get('/api/v1/users', HTTP_AUTHORIZATION=f'Token {token}')
     assert resp_2.status_code == 200

--- a/miqa/core/tests/test_rest.py
+++ b/miqa/core/tests/test_rest.py
@@ -9,6 +9,26 @@ from miqa.core.rest.user import UserSerializer
 
 
 @pytest.mark.django_db
+def test_api_token_access(user, api_client):
+    password = 'letmein'
+    user.set_password(password)
+    user.save()
+
+    resp_1 = api_client.post(
+        '/api-token-auth/',
+        data={
+            "username": user.username,
+            "password": password,
+        },
+    )
+    assert resp_1.status_code == 200
+    token = resp_1.json()["token"]
+
+    resp_2 = api_client.get('/api/v1/users', HTTP_AUTHORIZATION=f'Token {token}')
+    assert resp_2.status_code == 200
+
+
+@pytest.mark.django_db
 def test_projects_list(user_api_client, project, user):
     user_api_client = user_api_client()
     resp = user_api_client.get('/api/v1/projects')

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -70,6 +70,9 @@ class MiqaMixin(ConfigMixin):
         configuration.REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = [
             'rest_framework.permissions.IsAuthenticated'
         ]
+        configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
+            'rest_framework.authentication.TokenAuthentication',
+        ]
         configuration.REST_FRAMEWORK[
             'EXCEPTION_HANDLER'
         ] = 'miqa.core.rest.exceptions.custom_exception_handler'

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -6,7 +6,6 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
 from rest_framework.authtoken.views import obtain_auth_token
 
-
 from miqa.core.rest import (
     AccountActivateView,
     AccountInactiveView,

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -4,6 +4,8 @@ from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
+from rest_framework.authtoken.views import obtain_auth_token
+
 
 from miqa.core.rest import (
     AccountActivateView,
@@ -43,6 +45,7 @@ urlpatterns = [
     path('accounts/inactive/', AccountInactiveView.as_view()),
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path('api-token-auth/', obtain_auth_token),
     path('admin/', admin.site.urls),
     path('api/v1/s3-upload/', include('s3_file_field.urls')),
     path('api/v1/', include(router.urls)),


### PR DESCRIPTION
When going over the admin manual, @curtislisle brought up an excellent question about MIQA API access. Since we don't have a dedicated Python client, we should expose the proper `django-oauth` endpoints so the user can fetch their own token and use that for subsequent API calls.