### PR TITLE
Reorder production Dockerfile

### DIFF
--- a/prod/django.Dockerfile
+++ b/prod/django.Dockerfile
@@ -26,10 +26,10 @@ ARG DJANGO_MIQA_URL_PREFIX
 ARG DJANGO_SECRET_KEY
 COPY ./setup.py /opt/django-project/setup.py
 COPY ./manage.py /opt/django-project/manage.py
+COPY ./miqa /opt/django-project/miqa
 WORKDIR /opt/django-project/
 RUN pip install .[learning] && \
     ./manage.py collectstatic
-COPY ./miqa /opt/django-project/miqa
 
 # Web client:
 # * Build


### PR DESCRIPTION
For some reason the `collectstatic` step was failing because the `miqa` project was uninstalled. I'm not sure what changed to cause that to fail, but this should resolve the issue. It was only ordered that way in the past to optimize the build time a bit.