### PR TITLE
Attempted fix for OAuth logout bug

### DIFF
--- a/client/src/django.ts
+++ b/client/src/django.ts
@@ -53,8 +53,10 @@ const djangoClient = {
     await oauthClient.redirectToLogin();
   },
   async logout() {
-    await apiClient.post('/logout/', undefined, { withCredentials: true });
-    await oauthClient.logout();
+    await Promise.all([
+      apiClient.post('/logout/', undefined, { withCredentials: true }),
+      oauthClient.logout(),
+    ]);
   },
   async MIQAConfig() {
     const { data } = await apiClient.get('/configuration/');


### PR DESCRIPTION
This is my attempt to fix #460 

Calling `oauthClient.logout` _should_ be sufficient to clear the locally stored token. However, if the XHR to the logout endpoint failed, we were not reaching that call. That could happen if the user lost connectivity while idle, for instance.