### PR TITLE
Force Line Endings to *nix Style LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 samples/Demo[[:space:]]Project/IXI002 filter=lfs diff=lfs merge=lfs -text
 samples/Demo[[:space:]]Project/IXI016 filter=lfs diff=lfs merge=lfs -text
 *.nii.gz filter=lfs diff=lfs merge=lfs -text
-text eol=lf
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 samples/Demo[[:space:]]Project/IXI002 filter=lfs diff=lfs merge=lfs -text
 samples/Demo[[:space:]]Project/IXI016 filter=lfs diff=lfs merge=lfs -text
 *.nii.gz filter=lfs diff=lfs merge=lfs -text
+text eol=lf


### PR DESCRIPTION
On Windows, by default, Git will retrieve place files in local repo with Windows line endings (CRLF), this causes the instructions in dev/README.md to break when running `docker-compose run --rm django ./manage.py migrate`.

Since Docker is running Linux, when Python attempts to execute a script and finds a CRLF it interprets the CR as another instruction and the command fails to run.

By adding `* text=eol` all text files (no binary) will be forced to use LF even when the developer is on Windows.