### PR TITLE
Bug hunt 3

### DIFF
--- a/web_client/src/components/WindowWidget.vue
+++ b/web_client/src/components/WindowWidget.vue
@@ -76,7 +76,10 @@ export default defineComponent({
       currentRange.value = windowPresets.find(
         (preset) => preset.value === presetId,
       ).apply(widthMin.value, widthMax.value);
-      updateFromRange(currentRange.value);
+      const [v0, v1] = currentRange.value;
+      const ww = v1 - v0;
+      const wl = v0 + Math.floor(ww / 2);
+      updateRender(ww, wl);
     }
 
     onMounted(() => {

--- a/web_client/src/views/Projects.vue
+++ b/web_client/src/views/Projects.vue
@@ -149,7 +149,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div>
+  <div v-if="user">
     <Navbar />
     <div class="d-flex">
       <v-card class="project-list-container">


### PR DESCRIPTION
And a few more:

- applying a preset from the window widget would not result in an immediate render update; only the slider values would change. [0790a81](https://github.com/OpenImaging/miqa/pull/564/commits/0790a811eabe65a6a9dc3fe843a153956b387496) repeats the desired logic for `updateFromRange` without the conditionals.
- A recent [Sentry event ](https://sentry.io/organizations/kitware-data/issues/3504779759/events/1a573fba85db4fb1a78735051daa3317/) showed an edge case where the user was not defined and a view was loaded. [22c613e](https://github.com/OpenImaging/miqa/pull/564/commits/22c613e76984ffb4d7db96844806a1611d153fcf) makes the view conditionally depend on the user being defined.