### PR TITLE
Add json case to export method

### DIFF
--- a/miqa/core/conversion/import_export_csvs.py
+++ b/miqa/core/conversion/import_export_csvs.py
@@ -150,7 +150,7 @@ def import_dataframe_to_dict(df, project):
                                 'decision': scan_df['last_decision'].iloc[0],
                                 'creator': scan_df['last_decision_creator'].iloc[0],
                                 'note': scan_df['last_decision_note'].iloc[0],
-                                'created': scan_df['last_decision_created'].iloc[0],
+                                'created': str(scan_df['last_decision_created'].iloc[0]),
                                 'user_identified_artifacts': scan_df['identified_artifacts'].iloc[0]
                                 or None,
                                 'location': scan_df['location_of_interest'].iloc[0] or None,

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -383,7 +383,8 @@ def perform_export(project_id: Optional[str]):
             export_df.to_csv(export_path, index=False)
         elif export_path.endswith('json'):
             json_contents = import_dataframe_to_dict(export_df, project)
-            json.dump(json_contents, open(export_path, 'w'))
+            with open(export_path, 'w') as fd:
+                json.dump(json_contents, fd)
         else:
             raise APIException(
                 f'Unknown format for export path {export_path}. Expected csv or json.'

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -385,7 +385,9 @@ def perform_export(project_id: Optional[str]):
             json_contents = import_dataframe_to_dict(export_df, project)
             json.dump(json_contents, open(export_path, 'w'))
         else:
-            raise APIException(f'Unknown format for export path {export_path}. Expected csv or json.')
+            raise APIException(
+                f'Unknown format for export path {export_path}. Expected csv or json.'
+            )
     except PermissionError:
         raise APIException(f'MIQA lacks permission to write to {export_path}.')
     return export_warnings


### PR DESCRIPTION
Resolves #581 

I actually didn't account for the JSON case in the export method at all; it was saving with the CSV format no matter what the file extension was. It was therefore a quick fix to get it working.