### PR TITLE
Pin DRF to known working version

### DIFF
--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -222,7 +222,7 @@ def perform_import(import_dict):
                         if last_decision_dict['created']:
                             valid_dt = dateparser.parse(last_decision_dict['created'])
                             if valid_dt:
-                                created = valid_dt.strftime('%Y-%m-%d %H:$M')
+                                created = valid_dt.strftime('%Y-%m-%d %H:%M')
                         if last_decision_dict['location'] and last_decision_dict['location'] != '':
                             slices = [
                                 axis.split('=')[1]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'djangorestframework',
+        'djangorestframework==3.13.1',  # https://github.com/axnsan12/drf-yasg/issues/810
         'django-click',
         'django-guardian',
         'drf-yasg',


### PR DESCRIPTION
Due to the latest release from DRF being incompatible with DRF-YASG, we need to pin our DRF version to one we know to work. Otherwise we get this error from the django container:

```
  File "/home/.../lib/python3.6/site-packages/drf_yasg/inspectors/field.py", line 406, in <module>
    (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
AttributeError: module 'rest_framework.serializers' has no attribute 'NullBooleanField'
```

(Also includes a minor typo fix)