### PR TITLE
Run import step synchronously

### DIFF
--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -156,7 +156,7 @@ def import_data(project_id: Optional[str]):
         raise APIException(f'MIQA lacks permission to read {import_path}.')
 
     import_dict, not_found_errors = validate_import_dict(import_dict, project)
-    perform_import.delay(import_dict)
+    perform_import(import_dict)
     return not_found_errors
 
 


### PR DESCRIPTION
Intended to resolve #593 and resolve #601

I was not able to replicate the problem described in these two issues, so this was my best attempt without being able to verify. 

My guess is that previously, the only synchronous part of the import was to verify the validity of the import file. Objects made by the import were done asynchronously. Thus, when the synchronous part was done, it returned to the client and the client immediately updated the task overview. If the asynchronous part had not finished making the objects, the task overview would show up as having no objects within the project.

With this change, the part of the import that creates objects is now done synchronously, so the client won't get an answer (and won't request the task overview) until the objects are done saving to the database.

The most time-consuming part of the import is the evaluation step, and this part is still done asynchronously.