### PR TITLE
Fix `DecisionButtons.vue` sorting of `scanDecisions`

### DIFF
--- a/web_client/src/components/DecisionButtons.vue
+++ b/web_client/src/components/DecisionButtons.vue
@@ -69,7 +69,7 @@ export default {
     suggestedArtifacts() {
       if (this.currentViewData.scanDecisions && this.currentViewData.scanDecisions.length > 0) {
         const lastDecision = _.sortBy(
-          this.currentViewData.scanDecisions, (dec) => dec.created,
+          this.currentViewData.scanDecisions, (dec) => { Date.parse(dec.created); },
         )[0];
         const lastDecisionArtifacts = lastDecision.user_identified_artifacts;
         // Of the artifacts chosen in the last scandecision,


### PR DESCRIPTION
In the computed property `suggestedArtifacts` of `<DecisionButtons>` we get the latest scan decision and use it to mark the buttons/chips appropriately.

Because the date of the `scanDecision` was a string the sorting didn't always work (e.g., a scan from 9/10 might show up before a scan on 10/10).

By having the decision parsed as a date this issue appears to be fixed.