### PR TITLE
Scan Navigation

### DIFF
--- a/web_client/src/components/ControlPanel.vue
+++ b/web_client/src/components/ControlPanel.vue
@@ -92,6 +92,7 @@ export default {
     ...mapMutations([
       'setShowCrosshairs',
       'setStoreCrosshairs',
+      'setCurrentFrameId',
     ]),
     openScanLink() {
       window.open(this.currentViewData.scanLink, '_blank');
@@ -125,25 +126,25 @@ export default {
         }
       }
     },
-    navigateToFrame(frameId) {
-      if (frameId && frameId !== this.$route.params.frameId) {
+    navigateToScan(scanId) {
+      if (scanId && scanId !== this.$route.params.scanId) {
         this.$router
-          .push(`/${this.currentViewData.projectId}/${frameId}` || '')
+          .push(`/${this.currentViewData.projectId}/${scanId}` || '')
           .catch(this.handleNavigationError);
       }
     },
     slideToFrame(framePosition) {
-      this.navigateToFrame(this.currentViewData.scanFramesList[framePosition - 1]);
+      this.setCurrentFrameId(this.currentViewData.scanFramesList[framePosition - 1]);
     },
     updateImage() {
       if (this.direction === 'back') {
-        this.navigateToFrame(this.previousFrame);
+        this.setCurrentFrameId(this.previousFrame);
       } else if (this.direction === 'forward') {
-        this.navigateToFrame(this.nextFrame);
+        this.setCurrentFrameId(this.nextFrame);
       } else if (this.direction === 'previous') {
-        this.navigateToFrame(this.currentViewData.upTo);
+        this.navigateToScan(this.currentViewData.upTo);
       } else if (this.direction === 'next') {
-        this.navigateToFrame(this.currentViewData.downTo);
+        this.navigateToScan(this.currentViewData.downTo);
       }
     },
     handleKeyPress(direction) {

--- a/web_client/src/components/ControlPanel.vue
+++ b/web_client/src/components/ControlPanel.vue
@@ -126,10 +126,11 @@ export default {
         }
       }
     },
-    navigateToScan(scanId) {
-      if (scanId && scanId !== this.$route.params.scanId) {
+    navigateToScan(location) {
+      if (!location) location = 'complete';
+      if (location && location !== this.$route.params.scanId) {
         this.$router
-          .push(`/${this.currentViewData.projectId}/${scanId}` || '')
+          .push(`/${this.currentViewData.projectId}/${location}` || '')
           .catch(this.handleNavigationError);
       }
     },
@@ -356,7 +357,6 @@ export default {
                             <v-icon>fa-caret-up</v-icon>
                           </v-btn>
                           <v-btn
-                            :disabled="!currentViewData.downTo"
                             small
                             depressed
                             class="transparent-btn"

--- a/web_client/src/components/ExperimentsView.vue
+++ b/web_client/src/components/ExperimentsView.vue
@@ -96,8 +96,8 @@ export default {
       }
       return str;
     },
-    getURLForFirstFrameInScan(scanId) {
-      return `/${this.currentProject.id}/${this.scanFrames[scanId][0]}`;
+    getURLForScan(scanId) {
+      return `/${this.currentProject.id}/${scanId}`;
     },
     decisionToRating(decisions) {
       if (decisions.length === 0) return {};
@@ -304,7 +304,7 @@ export default {
                   <template #activator="{ on, attrs }">
                     <v-btn
                       v-bind="attrs"
-                      :to="getURLForFirstFrameInScan(scan.id)"
+                      :to="getURLForScan(scan.id)"
                       :disabled="!includeScan(scan.id)"
                       class="ml-0 px-1 scan-name"
                       href

--- a/web_client/src/components/ExperimentsView.vue
+++ b/web_client/src/components/ExperimentsView.vue
@@ -205,7 +205,7 @@ export default {
       >
         <span>All scans</span>
         <v-switch
-          :input-value="true"
+          :input-value="reviewMode"
           dense
           style="display: inline-block; max-height: 40px; max-width: 60px;"
           class="px-3 ma-0"

--- a/web_client/src/router.ts
+++ b/web_client/src/router.ts
@@ -15,6 +15,11 @@ export default new Router({
     },
     // Order matters
     {
+      path: '/:projectId?/complete',
+      name: 'projectComplete',
+      component: Projects,
+    },
+    {
       path: '/:projectId?/:scanId?',
       name: 'scan',
       component: Scan,

--- a/web_client/src/router.ts
+++ b/web_client/src/router.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Router from 'vue-router';
 
 import Projects from './views/Projects.vue';
-import Frame from './views/Frame.vue';
+import Scan from './views/Scan.vue';
 
 Vue.use(Router);
 
@@ -15,9 +15,9 @@ export default new Router({
     },
     // Order matters
     {
-      path: '/:projectId?/:frameId?',
-      name: 'frame',
-      component: Frame,
+      path: '/:projectId?/:scanId?',
+      name: 'scan',
+      component: Scan,
     },
     {
       path: '*',

--- a/web_client/src/store/index.ts
+++ b/web_client/src/store/index.ts
@@ -387,10 +387,8 @@ const {
         scanFramesList,
         scanPosition: experimentScansList.indexOf(scan.id) + 1,
         framePosition: scanFramesList.indexOf(currentFrame.id) + 1,
-        backTo: currentFrame.previousFrame,
-        forwardTo: currentFrame.nextFrame,
-        upTo: state.scanFrames[upTo] ? state.scanFrames[upTo][0] : undefined,
-        downTo: state.scanFrames[downTo] ? state.scanFrames[downTo][0] : undefined,
+        upTo,
+        downTo,
         currentFrame,
         currentAutoEvaluation: currentFrame.frame_evaluation,
       };
@@ -731,16 +729,16 @@ const {
         },
       });
     },
-    async getFrame({ state, dispatch }, { frameId, projectId }) {
-      if (!frameId) {
+    async getScan({ state, dispatch }, { scanId, projectId }) {
+      if (!scanId) {
         return undefined;
       }
-      if (!state.frames[frameId]) {
+      if (!state.scans[scanId]) {
         await dispatch('loadProjects');
         const targetProject = state.projects.filter((proj) => proj.id === projectId)[0];
         await dispatch('loadProject', targetProject);
       }
-      return state.frames[frameId];
+      return state.scans[scanId];
     },
     async setCurrentFrame({ commit }, frameId) {
       commit('setCurrentFrameId', frameId);
@@ -750,9 +748,6 @@ const {
     }, { frame, onDownloadProgress = null }) {
       if (!frame) {
         throw new Error("frame id doesn't exist");
-      }
-      if (getters.currentFrame === frame) {
-        return;
       }
       commit('setLoadingFrame', true);
       commit('setErrorLoadingFrame', false);

--- a/web_client/src/views/Scan.vue
+++ b/web_client/src/views/Scan.vue
@@ -20,14 +20,18 @@ export default {
   },
   inject: ['user'],
   async beforeRouteUpdate(to, from, next) {
-    const toFrameId = this.scanFrames[to.params.scanId][0];
-    const toFrame = this.frames[toFrameId];
-    next(true);
-    if (toFrame) {
-      this.swapToFrame({
-        frame: toFrame,
-        onDownloadProgress: this.onFrameDownloadProgress,
-      });
+    if (to.params.scanId === 'complete') {
+      next(true);
+    } else {
+      const toFrameId = this.scanFrames[to.params.scanId][0];
+      const toFrame = this.frames[toFrameId];
+      next(true);
+      if (toFrame) {
+        this.swapToFrame({
+          frame: toFrame,
+          onDownloadProgress: this.onFrameDownloadProgress,
+        });
+      }
     }
   },
   async beforeRouteLeave(to, from, next) {


### PR DESCRIPTION
Previously, the url for the main view contained the frame id, and the main view was different for each frame.
In order to  speed up the reaction time of the frame slider, the main view is routed by scan id. Changing the frame is a matter of changing the state only, not the whole main view.
