### PR TITLE
Minor refactoring of Vuex store for clarity, performance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}

--- a/web_client/src/components/DecisionButtons.vue
+++ b/web_client/src/components/DecisionButtons.vue
@@ -261,7 +261,7 @@ export default {
             } : {}),
           );
           addScanDecision({
-            currentScan: this.currentViewData.scanId,
+            currentScanId: this.currentViewData.scanId,
             newDecision: savedObj,
           });
           this.refreshTaskOverview();

--- a/web_client/src/store/index.ts
+++ b/web_client/src/store/index.ts
@@ -637,8 +637,8 @@ const {
       // place data in state
       const { experiments } = project;
 
-      for (let i = 0; i < experiments.length; i += 1) {
-        const experiment = experiments[i];
+      for (let experimentIndex = 0; experimentIndex < experiments.length; experimentIndex += 1) {
+        const experiment = experiments[experimentIndex];
         // set experimentScans[experiment.id] before registering the experiment.id
         // so ExperimentsView doesn't update prematurely
         commit('addExperiment', {
@@ -648,7 +648,7 @@ const {
             name: experiment.name,
             note: experiment.note,
             project: experiment.project,
-            index: i,
+            index: experimentIndex,
             lockOwner: experiment.lock_owner,
           },
         });
@@ -656,8 +656,8 @@ const {
         // TODO these requests *can* be run in parallel, or collapsed into one XHR
         // eslint-disable-next-line no-await-in-loop
         const { scans } = experiment;
-        for (let j = 0; j < scans.length; j += 1) {
-          const scan = scans[j];
+        for (let scanIndex = 0; scanIndex < scans.length; scanIndex += 1) {
+          const scan = scans[scanIndex];
           commit('addExperimentScans', { experimentId: experiment.id, scanId: scan.id });
 
           // TODO these requests *can* be run in parallel, or collapsed into one XHR
@@ -678,7 +678,7 @@ const {
             },
           });
 
-          const nextScan = getNextFrame(experiments, i, j);
+          const nextScan = getNextFrame(experiments, experimentIndex, scanIndex);
 
           for (let k = 0; k < frames.length; k += 1) {
             const frame = frames[k];


### PR DESCRIPTION
I did some minor refactoring in the Vuex store primarily to improve clarity for my purposes but thought it might be useful. Most involved the renaming of parameters to more specifically identify their content.

For example, the `getData` function has an `id` parameter but it is not clear what the `id` belongs to - by renaming to `frameId` this becomes clearer.

In addition, there was a promise (`loadResult.fileP`) that was nested a level deeper than necessary, so I flattened this to allow the promise to (potentially) return more quickly/clarify where the code failed.

1. `id` parameter of `getData` refactored to `frameId`
2. `fileP` in `loadFile` and `loadFileAndGetData` refactored to `cachedFile`
3. Unnest then/catch/finally in `loadResult.cachedFile`
4. Move `.then...` onto next line to match standard formatting
5. Refactor parameters `i, j` of `getNextFrame` to `experimentIndex, scanIndex`
6. Refactor `currentScan` param of `addScanDecision` to `currentScanId`
7. Refactor `setLoadingFrame` and `setErrorLoadingFrame` param `value` to `isLoading` and `isErrorLoading` respectively
8. Refactor `sid, id` params of `addScanFrames` to `scanId, frameId`
9. Refactor `eid, sid` params of `addExperimentScans` to `experimentId, scanId`
10. Refactor `id, value` of `addExperiment` to `experimentId, experiment`
11. Refactor use of `addExperiment` within `loadProject` to match params in 10
12. Refactor use of `addExperimentScans` within `loadProject` to match 9
13. Refactor use of `addScanFrames` in `loadProject` to match 8
14. Refator use of `getNextFrame` in `loadProject` to match 5.
15. Refactor use of `addScanDecision` in `DecisionButtons.vue` to match 6
