### PR TITLE
Minor/Simple Code Tweaks/Fixes

### DIFF
--- a/web_client/src/components/DataImportExport.vue
+++ b/web_client/src/components/DataImportExport.vue
@@ -187,7 +187,7 @@ export default defineComponent({
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
-        <v-card-title class="title">
+        <v-card-title class="text-h6">
           Import
         </v-card-title>
         <v-card-text v-if="isGlobal">
@@ -232,7 +232,7 @@ export default defineComponent({
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
-        <v-card-title class="title">
+        <v-card-title class="text-h6">
           Messages Encountered
         </v-card-title>
         <div class="px-5">

--- a/web_client/src/components/EmailDialog.vue
+++ b/web_client/src/components/EmailDialog.vue
@@ -158,7 +158,7 @@ export default defineComponent({
       @submit.prevent="send"
     >
       <v-card>
-        <v-card-title class="headline grey lighten-4">
+        <v-card-title class="text-h5 grey lighten-4">
           Send email
           <v-spacer />
           <v-btn

--- a/web_client/src/components/KeyboardShortcutDialog.vue
+++ b/web_client/src/components/KeyboardShortcutDialog.vue
@@ -48,7 +48,7 @@ export default defineComponent({
   >
     <v-card>
       <v-card-title
-        class="title"
+        class="text-h6"
         primary-title
       >
         Keyboard shortcuts & Viewer Interaction

--- a/web_client/src/components/ProjectSettings.vue
+++ b/web_client/src/components/ProjectSettings.vue
@@ -268,6 +268,6 @@ export default defineComponent({
   min-height: 10vw;
   padding: 20px;
   background-color: white!important;
-  color: '#333333'!important;
+  color: #333333 !important;
 }
 </style>

--- a/web_client/src/components/ProjectUsers.vue
+++ b/web_client/src/components/ProjectUsers.vue
@@ -388,6 +388,6 @@ export default {
   min-height: 20vw;
   padding: 20px;
   background-color: white!important;
-  color: '#333333'!important;
+  color: #333333 !important;
 }
 </style>

--- a/web_client/src/components/ScanDecision.vue
+++ b/web_client/src/components/ScanDecision.vue
@@ -124,7 +124,7 @@ export default {
 
 <style scoped>
 .col{
-  padding: 0px;
-  margin: 0px;
+  padding: 0;
+  margin: 0;
 }
 </style>

--- a/web_client/src/components/VtkViewer.vue
+++ b/web_client/src/components/VtkViewer.vue
@@ -457,8 +457,8 @@ export default {
     position: fixed;
     top: 48px;
     left: 55px;
-    bottom: 0px;
-    right: 0px;
+    bottom: 0;
+    right: 0;
     z-index: 2;
   }
 
@@ -526,7 +526,7 @@ export default {
   }
 
   .viewer {
-    flex: 1 1 0px;
+    flex: 1 1 0;
     position: relative;
     overflow-y: hidden;
     display: flex;
@@ -534,7 +534,7 @@ export default {
   }
 
   .viewer > div {
-    flex: 1 1 0px;
+    flex: 1 1 0;
     position: relative;
     overflow-y: hidden;
     cursor: crosshair!important;

--- a/web_client/src/main.ts
+++ b/web_client/src/main.ts
@@ -12,9 +12,6 @@ import router from './router';
 import store from './store';
 import { STATIC_PATH } from './constants';
 
-import 'vuetify/dist/vuetify.min.css';
-import '@mdi/font/css/materialdesignicons.min.css';
-
 import './vtk/ColorMaps';
 import vMousetrap from './vue-utilities/v-mousetrap';
 import snackbarService from './vue-utilities/snackbar-service';

--- a/web_client/src/views/Projects.vue
+++ b/web_client/src/views/Projects.vue
@@ -360,7 +360,7 @@ export default defineComponent({
         >
           <div
             v-if="complete"
-            class="title text-center"
+            class="text-h6 text-center"
           >
             Viewed all scans in Project {{ currentProject.name }}.
             <div
@@ -394,13 +394,13 @@ export default defineComponent({
           </div>
           <div
             v-else-if="projects.length > 0"
-            class="title"
+            class="text-h6"
           >
             Select a project
           </div>
           <div
             v-else
-            class="title"
+            class="text-h6"
           >
             <v-progress-circular
               v-if="loadingProjects"

--- a/web_client/src/views/Scan.vue
+++ b/web_client/src/views/Scan.vue
@@ -199,7 +199,7 @@ export default {
           justify-center
           fill-height
         >
-          <div class="title">
+          <div class="text-h6">
             Error loading this frame
           </div>
         </v-layout>
@@ -220,7 +220,7 @@ export default {
 
   .view {
     position: relative;
-    flex: 1 0 0px;
+    flex: 1 0 0;
 
     border: 1.5px solid white;
     border-top: none;

--- a/web_client/src/vue-utilities/prompt-service/Prompt.vue
+++ b/web_client/src/vue-utilities/prompt-service/Prompt.vue
@@ -6,7 +6,7 @@
     <v-card>
       <v-card-title
         v-if="title"
-        class="title"
+        class="text-h6"
       >
         {{ title }}
       </v-card-title>


### PR DESCRIPTION
(ordered roughly from most to least signficant):
1. Vuetify auto-loads its own css files, so loading `vuetify.min.css` and `materialdesignicons.min.css` in `main.ts` causes stylesheets to be loaded twice
2. The hex codes for the `color` property of CSS should be unquoted
3. Vuetify now uses `text-h6` instead of `title`, `text-h5` instead of `headline`
4. Only using units on CSS styles when a non-zero value has been specified is currently considered best practice