### PR TITLE
Move definition of celery beat schedule

### DIFF
--- a/.github/actions/tox/action.yml
+++ b/.github/actions/tox/action.yml
@@ -5,15 +5,15 @@ runs:
     - uses: actions/setup-python@v2
       with:
         python-version: "3.8"
-    - name: cache-tox
-      id: cache-tox
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-tox
-      with:
-        path: ./.tox/
-        key: ${{ runner.os }}-tox-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: ${{ runner.os }}-tox-
+    # - name: cache-tox
+    #   id: cache-tox
+    #   uses: actions/cache@v3
+    #   env:
+    #     cache-name: cache-tox
+    #   with:
+    #     path: ./.tox/
+    #     key: ${{ runner.os }}-tox-${{ hashFiles('**/requirements*.txt') }}
+    #     restore-keys: ${{ runner.os }}-tox-
     - name: install-tox
       shell: bash
       run: |

--- a/miqa/core/management/commands/makeclient.py
+++ b/miqa/core/management/commands/makeclient.py
@@ -22,16 +22,19 @@ def command(username, uri):
     if username:
         user = User.objects.get(username=username)
     else:
-        user = User.objects.first()
+        first_user = User.objects.first()
+        if first_user:
+            user = first_user
 
-    application = Application(
-        name='miqa-client',
-        client_id=CLIENT_ID,
-        client_secret='',
-        client_type='public',
-        redirect_uris=uri,
-        authorization_grant_type='authorization-code',
-        user_id=user.id,
-        skip_authorization=True,
-    )
-    application.save()
+    if user:
+        application = Application(
+            name='miqa-client',
+            client_id=CLIENT_ID,
+            client_secret='',
+            client_type='public',
+            redirect_uris=uri,
+            authorization_grant_type='authorization-code',
+            user_id=user.username,
+            skip_authorization=True,
+        )
+        application.save()


### PR DESCRIPTION
The demo instance hasn't been running the reset task. Moving the definition fixed this in a dev env.