### PR TITLE
Fix updating window on frame change

### DIFF
--- a/web_client/src/components/WindowWidget.vue
+++ b/web_client/src/components/WindowWidget.vue
@@ -32,10 +32,10 @@ export default defineComponent({
       width: currentWindowWidth.value,
       level: currentWindowLevel.value,
     }));
-    const data = props.representation.getInputDataSet();
-    const distribution = data.computeHistogram(data.getBounds());
-    const widthMin = computed(() => distribution.minimum || 0);
-    const widthMax = computed(() => distribution.maximum || 0);
+    const data = computed(() => props.representation.getInputDataSet());
+    const distribution = computed(() => data.value.computeHistogram(data.value.getBounds()));
+    const widthMin = computed(() => distribution.value.minimum || 0);
+    const widthMax = computed(() => distribution.value.maximum || 0);
     const selectedPreset = ref();
     const windowLocked = computed(() => store.state.windowLocked.lock);
     const windowLockImage = computed(() => store.state.windowLocked.associatedImage);
@@ -71,8 +71,8 @@ export default defineComponent({
     function autoRange() {
       if (windowLocked.value) return;
       currentRange.value = [
-        Math.floor(distribution.minimum + distribution.sigma),
-        Math.floor(distribution.maximum - distribution.sigma),
+        Math.floor(distribution.value.minimum + distribution.value.sigma),
+        Math.floor(distribution.value.maximum - distribution.value.sigma),
       ];
       const ww = currentRange.value[1] - currentRange.value[0];
       const wl = currentRange.value[0] + Math.floor(ww / 2);

--- a/web_client/src/store/index.ts
+++ b/web_client/src/store/index.ts
@@ -51,7 +51,9 @@ function prepareProxyManager(proxyManager) {
       view.getRepresentations().forEach((representation) => {
         representation.setInterpolationType(InterpolationType.NEAREST);
         representation.onModified(macro.debounce(() => {
-          if (view.getRepresentations()) view.render(true);
+          if (view.getRepresentations()) {
+            view.render(true);
+          }
         }, 0));
         // debounce timer doesn't need a wait time because
         // the many onModified changes that it needs to collapse to a single rerender

--- a/web_client/src/store/index.ts
+++ b/web_client/src/store/index.ts
@@ -51,7 +51,7 @@ function prepareProxyManager(proxyManager) {
       view.getRepresentations().forEach((representation) => {
         representation.setInterpolationType(InterpolationType.NEAREST);
         representation.onModified(macro.debounce(() => {
-          view.render(true);
+          if (view.getRepresentations()) view.render(true);
         }, 0));
         // debounce timer doesn't need a wait time because
         // the many onModified changes that it needs to collapse to a single rerender


### PR DESCRIPTION
When switching between images, the automatic range values were computing to the same min and max because the distribution value was not updating to the new image. Making the image data and distribution data _computed values_ ensured that they change when the image changes.