### PR TITLE
Update formatting and typing

### DIFF
--- a/miqa/core/migrations/0001_default_site.py
+++ b/miqa/core/migrations/0001_default_site.py
@@ -26,7 +26,6 @@ def rollback_default_site(apps: StateApps, schema_editor: BaseDatabaseSchemaEdit
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         # This is the final sites app migration
         ('sites', '0002_alter_domain_unique'),

--- a/miqa/core/migrations/0002_initial.py
+++ b/miqa/core/migrations/0002_initial.py
@@ -10,7 +10,6 @@ import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/miqa/core/migrations/0003_image_paths_unique.py
+++ b/miqa/core/migrations/0003_image_paths_unique.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0002_initial'),
     ]

--- a/miqa/core/migrations/0004_auto_20210601_1222.py
+++ b/miqa/core/migrations/0004_auto_20210601_1222.py
@@ -9,7 +9,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0003_image_paths_unique'),

--- a/miqa/core/migrations/0005_auto_20210601_1512.py
+++ b/miqa/core/migrations/0005_auto_20210601_1512.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0004_auto_20210601_1222'),
     ]

--- a/miqa/core/migrations/0006_auto_20210609_1551.py
+++ b/miqa/core/migrations/0006_auto_20210609_1551.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0005_auto_20210601_1512'),
     ]

--- a/miqa/core/migrations/0007_add_initials.py
+++ b/miqa/core/migrations/0007_add_initials.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0006_auto_20210609_1551'),

--- a/miqa/core/migrations/0008_optional_annotation_creator.py
+++ b/miqa/core/migrations/0008_optional_annotation_creator.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0007_add_initials'),

--- a/miqa/core/migrations/0009_session_lock_owner.py
+++ b/miqa/core/migrations/0009_session_lock_owner.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0008_optional_annotation_creator'),

--- a/miqa/core/migrations/0010_auto_20210812_1545.py
+++ b/miqa/core/migrations/0010_auto_20210812_1545.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0009_session_lock_owner'),

--- a/miqa/core/migrations/0011_session_archived.py
+++ b/miqa/core/migrations/0011_session_archived.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0010_auto_20210812_1545'),
     ]

--- a/miqa/core/migrations/0012_alter_experiment_lock_owner.py
+++ b/miqa/core/migrations/0012_alter_experiment_lock_owner.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0011_session_archived'),

--- a/miqa/core/migrations/0013_evaluations.py
+++ b/miqa/core/migrations/0013_evaluations.py
@@ -11,7 +11,6 @@ def default_evaluation_model_mapping():
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('core', '0013_auto_20210917_1235'),
         ('core', '0014_evaluation'),

--- a/miqa/core/migrations/0014_rename_session_to_project.py
+++ b/miqa/core/migrations/0014_rename_session_to_project.py
@@ -43,7 +43,6 @@ def migrate_sessions_to_projects(apps: StateApps, schema_editor: BaseDatabaseSch
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0013_evaluations'),

--- a/miqa/core/migrations/0015_scan_image_relationship.py
+++ b/miqa/core/migrations/0015_scan_image_relationship.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0014_rename_session_to_project'),
     ]

--- a/miqa/core/migrations/0016_scan_decision.py
+++ b/miqa/core/migrations/0016_scan_decision.py
@@ -9,7 +9,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0015_scan_image_relationship'),

--- a/miqa/core/migrations/0017_remove_site.py
+++ b/miqa/core/migrations/0017_remove_site.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0016_scan_decision'),
     ]

--- a/miqa/core/migrations/0018_image_to_frame.py
+++ b/miqa/core/migrations/0018_image_to_frame.py
@@ -4,7 +4,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0017_remove_site'),
     ]

--- a/miqa/core/migrations/0019_unique_evaluation.py
+++ b/miqa/core/migrations/0019_unique_evaluation.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0018_image_to_frame'),
     ]

--- a/miqa/core/migrations/0020_alter_project_options.py
+++ b/miqa/core/migrations/0020_alter_project_options.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0019_unique_evaluation'),
     ]

--- a/miqa/core/migrations/0021_update_qc_options.py
+++ b/miqa/core/migrations/0021_update_qc_options.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0020_alter_project_options'),
     ]

--- a/miqa/core/migrations/0022_project_global_import_export.py
+++ b/miqa/core/migrations/0022_project_global_import_export.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0021_update_qc_options'),
     ]

--- a/miqa/core/migrations/0023_user_identified_artifacts.py
+++ b/miqa/core/migrations/0023_user_identified_artifacts.py
@@ -6,7 +6,6 @@ import miqa.core.models.scan_decision
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0022_project_global_import_export'),
     ]

--- a/miqa/core/migrations/0024_alter_frame_raw_path.py
+++ b/miqa/core/migrations/0024_alter_frame_raw_path.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0023_user_identified_artifacts'),
     ]

--- a/miqa/core/migrations/0025_globals_and_decisions.py
+++ b/miqa/core/migrations/0025_globals_and_decisions.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0024_alter_frame_raw_path'),
     ]

--- a/miqa/core/migrations/0026_frame_content.py
+++ b/miqa/core/migrations/0026_frame_content.py
@@ -5,7 +5,6 @@ import s3_file_field.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0025_globals_and_decisions'),
     ]

--- a/miqa/core/migrations/0027_experiment_lock_time.py
+++ b/miqa/core/migrations/0027_experiment_lock_time.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0026_frame_content'),
     ]

--- a/miqa/core/migrations/0028_project_settings_optional_fields.py
+++ b/miqa/core/migrations/0028_project_settings_optional_fields.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0027_experiment_lock_time'),
     ]

--- a/miqa/core/migrations/0029_project_email_recipients.py
+++ b/miqa/core/migrations/0029_project_email_recipients.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0028_project_settings_optional_fields'),
     ]

--- a/miqa/core/migrations/0030_optional_scan_fields.py
+++ b/miqa/core/migrations/0030_optional_scan_fields.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0029_project_email_recipients'),
     ]

--- a/miqa/core/migrations/0030_project_s3_public.py
+++ b/miqa/core/migrations/0030_project_s3_public.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0029_project_email_recipients'),
     ]

--- a/miqa/core/migrations/0030_scan_subject_session.py
+++ b/miqa/core/migrations/0030_scan_subject_session.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0029_project_email_recipients'),
     ]

--- a/miqa/core/migrations/0031_merge_20220414_1433.py
+++ b/miqa/core/migrations/0031_merge_20220414_1433.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0030_optional_scan_fields'),
         ('core', '0030_project_s3_public'),

--- a/miqa/core/migrations/0032_merge_20220422_1716.py
+++ b/miqa/core/migrations/0032_merge_20220422_1716.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0030_scan_subject_session'),
         ('core', '0031_merge_20220414_1433'),

--- a/miqa/core/migrations/0033_project_anatomy_orientation.py
+++ b/miqa/core/migrations/0033_project_anatomy_orientation.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0032_merge_20220422_1716'),
     ]

--- a/miqa/core/migrations/0034_CT_scan_type.py
+++ b/miqa/core/migrations/0034_CT_scan_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0033_project_anatomy_orientation'),
     ]

--- a/miqa/core/migrations/0035_allow_null_decision_creation_times.py
+++ b/miqa/core/migrations/0035_allow_null_decision_creation_times.py
@@ -5,7 +5,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('core', '0034_CT_scan_type'),
     ]

--- a/miqa/core/rest/email.py
+++ b/miqa/core/rest/email.py
@@ -12,7 +12,6 @@ from rest_framework.views import APIView
 
 class EmailView(APIView):
     def post(self, request, format=None):
-
         msg = EmailMultiAlternatives(
             request.data['subject'],
             request.data['body'],
@@ -24,7 +23,6 @@ class EmailView(APIView):
         )
 
         for index, screenshot in enumerate(request.data['screenshots']):
-
             # parse data uri to extract mime type and base64 data
             # assumptions: mime type is image/jpeg or image/png
             match = re.fullmatch(

--- a/miqa/core/rest/experiment.py
+++ b/miqa/core/rest/experiment.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.utils import timezone
@@ -136,7 +138,7 @@ class ExperimentViewSet(ReadOnlyModelViewSet, mixins.CreateModelMixin, mixins.De
                 )
                 and (
                     experiment.lock_time is None
-                    or timezone.now() - experiment.lock_time < timezone.timedelta(minutes=5)
+                    or timezone.now() - experiment.lock_time < timedelta(minutes=5)
                 )
             ):
                 raise LockContention()

--- a/miqa/core/rest/permissions.py
+++ b/miqa/core/rest/permissions.py
@@ -1,8 +1,8 @@
+from functools import wraps
 from typing import Union
 
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
-from django.utils.functional import wraps
 from django.views.generic import View
 from guardian.shortcuts import get_perms
 from rest_framework import status

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -259,7 +259,6 @@ def perform_import(import_dict):
                         new_scan_decisions.append(decision)
                 new_scans.append(scan_object)
                 for frame_number, frame_data in scan_data['frames'].items():
-
                     if frame_data['file_location']:
                         frame_object = Frame(
                             frame_number=frame_number,

--- a/miqa/core/tests/pyppeteer/test_save_decisions.py
+++ b/miqa/core/tests/pyppeteer/test_save_decisions.py
@@ -94,7 +94,7 @@ async def test_save_decisions_tier_1(
 
     # confirm that the number of scans awaiting tier 2 review is 1;
     # only the second scan does not have "Usable" as the latest decision
-    complete_span = await (page.waitForXPath('//span[contains(., "tier 2 review (")]'))
+    complete_span = await page.waitForXPath('//span[contains(., "tier 2 review (")]')
     complete_text = (await page.evaluate('(element) => element.textContent', complete_span)).strip()
     assert complete_text == 'needs tier 2 review (1)'
 
@@ -151,6 +151,6 @@ async def test_save_decisions_tier_2(
     await page.waitFor(3_000)
 
     # confirm that the number of complete scans is 2
-    complete_span = await (page.waitForXPath('//span[contains(., "complete (")]'))
+    complete_span = await page.waitForXPath('//span[contains(., "complete (")]')
     complete_text = (await page.evaluate('(element) => element.textContent', complete_span)).strip()
     assert complete_text == 'complete (2)'

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -1,6 +1,7 @@
 # flake8: noqa N802
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 
 from composed_configuration import (
@@ -14,7 +15,6 @@ from composed_configuration import (
     SmtpEmailMixin,
     TestingBaseConfiguration,
 )
-from datetime import timedelta
 from composed_configuration._configuration import _BaseConfiguration
 from configurations import values
 

--- a/web_client/public/index.html
+++ b/web_client/public/index.html
@@ -1,21 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-    <title>MIQA</title>
-    <!-- TODO: bundle fonts -->
-    <link href='https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons' rel="stylesheet">
-    <link href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" rel="stylesheet">
-  </head>
-  <body>
-    <noscript>
-      <strong>We're sorry but MIQA doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-    </noscript>
-    <div id="app"></div>
-    <!-- built files will be auto injected -->
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <title>MIQA</title>
+  <!-- TODO: bundle fonts -->
+  <link href='https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons' rel="stylesheet">
+  <link href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet">
+</head>
+
+<body>
+  <noscript>
+    <strong>We're sorry but MIQA doesn't work properly without JavaScript enabled. Please enable it to
+      continue.</strong>
+  </noscript>
+  <div id="app"></div>
+  <!-- built files will be auto injected -->
+</body>
+
 </html>


### PR DESCRIPTION
These are fixes for the currently failing tests on master.

Most of these changes are automatic reformatting from running `tox -e format`. 
The only manual changes I made were the following:
 - Fix type errors in `miqa/core/rest/experiment.py` and `miqa/core/rest/permissions.py`
 - Fix material design icons so pyppeteer tests would pass (mdi buttons were not appearing)