### PR TITLE
Use most recent decision for each scan in ExperimentsList

### DIFF
--- a/web_client/src/components/ExperimentsView.vue
+++ b/web_client/src/components/ExperimentsView.vue
@@ -59,7 +59,7 @@ export default defineComponent({
     function decisionToRating(decisions) {
       // decisions are an array of objects
       if (decisions.length === 0) return {};
-      const rating = _.first(_.sortBy(decisions, (decision) => decision.created)).decision;
+      const rating = _.last(_.sortBy(decisions, (decision) => decision.created)).decision;
       let color = 'grey--text';
       if (rating === 'U') {
         color = 'green--text';


### PR DESCRIPTION
From @kipohl via Slack:

> the project pages are never updated once the status of the scan changed (in the list below they are all usable or unusable)

![image](https://user-images.githubusercontent.com/44912689/235502672-b8fceb14-1240-4ffe-a402-71913a727c19.png)


The problem arose because of a simple logic error in the `ExperimentsView` component; after sorting the list of decisions on each scan, we selected the _first_ item instead of the _last_ (most recent) one.