### PR TITLE
Fix reset demo logic

### DIFF
--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -51,10 +51,21 @@ def _download_from_s3(path: str, public: bool) -> bytes:
 
 @shared_task
 def reset_demo():
-    demo_project = Project.objects.get(name='Demo Project')
-    demo_project.import_path = 's3://miqa-storage/miqa.csv'
-    demo_project.export_path = 'samples/demo.json'
-    demo_project.save()
+    demo_user = User.objects.get(username='test@miqa.dev')
+    demo_project, created = Project.objects.get_or_create(
+        name='Demo Project',
+        defaults={
+            'creator': demo_user,
+            'import_path': 's3://miqa-storage/IXI_demo.csv',
+            'export_path': 'samples/demo.json',
+        },
+    )
+    if not created:
+        demo_project.creator = demo_user
+        demo_project.import_path = 's3://miqa-storage/IXI_demo.csv'
+        demo_project.export_path = 'samples/demo.json'
+        demo_project.save()
+
     import_data(demo_project.id)
     Project.objects.exclude(id=demo_project.id).delete()
 


### PR DESCRIPTION
Under the old logic, if the Demo Project was deleted or renamed, the reset would fail.

Also, the import file path on S3 was incorrect. This was also fixed.