### PR TITLE
Disable scheduled CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   lint:

--- a/miqa/core/models/frame.py
+++ b/miqa/core/models/frame.py
@@ -11,7 +11,7 @@ from django.db import models
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django_extensions.db.models import TimeStampedModel
-from s3_file_field import S3FileField
+from s3_file_field.fields import S3FileField
 
 from miqa.core.conversion.nifti_to_zarr_ngff import convert_to_store_path
 

--- a/miqa/core/tasks.py
+++ b/miqa/core/tasks.py
@@ -51,7 +51,7 @@ def _download_from_s3(path: str, public: bool) -> bytes:
 
 @shared_task
 def reset_demo():
-    Project.objects.delete()
+    Project.objects.all().delete()
 
     demo_project = Project(
         name='Demo Project',

--- a/miqa/learning/evaluation_models.py
+++ b/miqa/learning/evaluation_models.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
 
@@ -13,7 +13,7 @@ class EvaluationModel(ABC):
         self.expected_outputs = expected_outputs
         super().__init__()
 
-    @abstractclassmethod
+    @abstractmethod
     def load(self):
         pass
 

--- a/miqa/settings.py
+++ b/miqa/settings.py
@@ -98,6 +98,10 @@ class MiqaMixin(ConfigMixin):
             'EXCEPTION_HANDLER'
         ] = 'miqa.core.rest.exceptions.custom_exception_handler'
 
+        configuration.MIDDLEWARE += [
+            'allauth.account.middleware.AccountMiddleware',
+        ]
+
 
 class DevelopmentConfiguration(MiqaMixin, DevelopmentBaseConfiguration):
     HOMEPAGE_REDIRECT_URL = values.Value(environ=True, default='http://localhost:8081')


### PR DESCRIPTION
GitHub disables the workflow completely if you don't have any code changes for 60 days. Unfortunately they don't only disable the scheduled trigger, but _all_ triggers, so CI wasn't running on PRs either.

Since this repo is mostly dormant, I'm turning off the schedule to prevent this happening in the future.